### PR TITLE
Add mod removal to launcher

### DIFF
--- a/src/main/java/net/technicpack/launchercore/install/InstalledPack.java
+++ b/src/main/java/net/technicpack/launchercore/install/InstalledPack.java
@@ -56,7 +56,7 @@ public class InstalledPack {
 	private transient File savesDir;
 	private transient File cacheDir;
 	private transient File resourceDir;
-	private transient File coremodsDir;
+	private transient File modsDir;
 	private transient PackInfo info;
 	private transient PackRefreshListener refreshListener;
 	private String name;
@@ -103,14 +103,14 @@ public class InstalledPack {
 		savesDir = new File(installedDirectory, "saves");
 		cacheDir = new File(installedDirectory, "cache");
 		resourceDir = new File(installedDirectory, "resources");
-		coremodsDir = new File(installedDirectory, "coremods");
+		modsDir = new File(installedDirectory, "mods");
 
 		binDir.mkdirs();
 		configDir.mkdirs();
 		savesDir.mkdirs();
 		cacheDir.mkdirs();
 		resourceDir.mkdirs();
-		coremodsDir.mkdirs();
+		modsDir.mkdirs();
 	}
 
 	public String getDisplayName() {
@@ -197,8 +197,8 @@ public class InstalledPack {
 		return resourceDir;
 	}
 
-	public File getCoremodsDir() {
-		return coremodsDir;
+	public File getModsDir() {
+		return modsDir;
 	}
 
 	public synchronized BufferedImage getLogo() {

--- a/src/main/java/net/technicpack/launchercore/install/ModpackInstaller.java
+++ b/src/main/java/net/technicpack/launchercore/install/ModpackInstaller.java
@@ -112,6 +112,13 @@ public class ModpackInstaller {
 	}
 
 	private void installModpack(Modpack modpack) throws IOException {
+		File modsDir = installedPack.getModsDir();
+
+		for (File mod : modsDir.listFiles()) {
+			if (mod.isDirectory()) continue;
+			mod.delete();
+		}
+
 		for (Mod mod : modpack.getMods()) {
 			installMod(mod);
 		}


### PR DESCRIPTION
This will 'clean' the mods directory every update, but will
leave directories intact. This should fix mod updates with different
names.

Signed-off-by: Tristen Allen spyboticsguy@gmail.com
