### PR TITLE
Add recursive mod deletion

### DIFF
--- a/src/main/java/net/technicpack/launchercore/install/ModpackInstaller.java
+++ b/src/main/java/net/technicpack/launchercore/install/ModpackInstaller.java
@@ -274,18 +274,15 @@ public class ModpackInstaller {
 
 	private void deleteMods(File modsDir) throws CacheDeleteException {
 		for (File mod : modsDir.listFiles()) {
-			
 			if (mod.isDirectory()) {
-				File modDir = mod;
-				for (File modRecurse : modDir.listFiles()) {
-					if (modRecurse.getName().endsWith(".zip") || modRecurse.getName().endsWith(".jar")) modRecurse.delete();
-					if (modRecurse.isDirectory()) deleteMods(modRecurse);
-				}
+				deleteMods(mod);
 				continue;
 			}
 
-			if (!mod.delete()) {
-				throw new CacheDeleteException(mod.getAbsolutePath());
+			if (mod.getName().endsWith(".zip") || mod.getName().endsWith(".jar")) {
+				if (!mod.delete()) {
+					throw new CacheDeleteException(mod.getAbsolutePath());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When updating between versions of MC, certain version-dependent libraries were not being deleted, causing duplicate libraries to be present upon updating. This PR adds recursive mod deletion that only matches files with a '.zip' or a '.jar' extension.
