### PR TITLE
Minor: Clear error message in case of successful DL but if not a valid ZIP

### DIFF
--- a/src/main/java/net/technicpack/launchercore/mirror/MirrorStore.java
+++ b/src/main/java/net/technicpack/launchercore/mirror/MirrorStore.java
@@ -126,6 +126,8 @@ public class MirrorStore {
                 if (download.getOutFile().exists() && (verifier == null || verifier.isFileValid(download.getOutFile()))) {
                     outputFile = download.getOutFile();
                     break;
+                } else if (verifier != null) {
+                    System.err.println("Download of " + url + " OK, but is not a valid (ZIP?) file: " + download.getOutFile().toString());
                 }
             }
         }

--- a/src/main/java/net/technicpack/launchercore/mirror/download/Download.java
+++ b/src/main/java/net/technicpack/launchercore/mirror/download/Download.java
@@ -61,7 +61,6 @@ public class Download implements Runnable {
 	}
 
 	@Override
-	@SuppressWarnings("unused")
 	public void run() {
 		ReadableByteChannel rbc = null;
 		FileOutputStream fos = null;


### PR DESCRIPTION
This is useful to debug problems e.g. when using Dropbox to host Mod Packs and when forgetting the &dl=1 parameter Dropbox needs to serve the ZIP instead of its HTML page. Before this micro enhancement, one (me..) may think that the DL didn't work, when it actually did - it just didn't download a ZIP (as the codes checks). With this additional log, it's clearer to the end-user why a (non-ZIP) "mod pack was not downloaded".

Unrelated: Removed no longer needed @SuppressWarnings("unused")