### PR TITLE
Fix downloading from redirected URLs

### DIFF
--- a/src/main/java/net/technicpack/launchercore/mirror/download/Download.java
+++ b/src/main/java/net/technicpack/launchercore/mirror/download/Download.java
@@ -70,8 +70,17 @@ public class Download implements Runnable {
             int responseFamily = response / 100;
 
             if (responseFamily == 3) {
-                throw new DownloadException("The server issued a redirect response which Technic failed to follow.");
-            } else if (responseFamily != 2) {
+                //throw new DownloadException("The server issued a redirect response which Technic failed to follow.");
+
+                String redirectLocation = conn.getHeaderField("Location");
+                System.out.println("Redirection URL Detected. New URL: " + redirectLocation);
+                URL redirectURL = new URL(redirectLocation);
+                conn = Utils.openHttpConnection(redirectURL);
+                response = conn.getResponseCode();
+                responseFamily = response / 100;
+            }
+
+            if (responseFamily != 2) {
                 throw new DownloadException("The server issued a " + response + " response code.");
             }
 


### PR DESCRIPTION
This should fix providing a URL shortener (ex: goo.gl) as long as they properly return a 3xx HTTP status code. All of these status codes require that the URL of the redirect target be given in the "Location" header of the HTTP response. 
