### PR TITLE
Fix downloading from redirected URLs

### DIFF
--- a/src/main/java/net/technicpack/launchercore/TechnicConstants.java
+++ b/src/main/java/net/technicpack/launchercore/TechnicConstants.java
@@ -23,7 +23,25 @@ public class TechnicConstants {
     public static final String technicURL = "http://mirror.technicpack.net/Technic/";
     public static final String technicVersions = technicURL + "version/";
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/TechnicConstants.java
     public static String getTechnicVersionJson(String version) {
         return technicVersions + version + "/" + version + ".json";
     }
+=======
+public interface Version {
+
+    public String getId();
+
+    public ReleaseType getType();
+
+    public void setType(ReleaseType releaseType);
+
+    public Date getUpdatedTime();
+
+    public void setUpdatedTime(Date updatedTime);
+
+    public Date getReleaseTime();
+
+    public void setReleaseTime(Date releaseTime);
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/minecraft/Version.java
 }

--- a/src/main/java/net/technicpack/launchercore/auth/AuthResponse.java
+++ b/src/main/java/net/technicpack/launchercore/auth/AuthResponse.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.auth;
+
+import java.util.Arrays;
+
+public class AuthResponse extends Response {
+    private String accessToken;
+    private String clientToken;
+    private Profile[] availableProfiles;
+    private Profile selectedProfile;
+    private User user;
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getClientToken() {
+        return clientToken;
+    }
+
+    public Profile[] getAvailableProfiles() {
+        return availableProfiles;
+    }
+
+    public Profile getSelectedProfile() {
+        return selectedProfile;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    @Override
+    public String getError() {
+        String error = super.getError();
+
+        if (this.availableProfiles != null && this.availableProfiles.length == 0 && (error == null || error.isEmpty())) {
+            return "No Minecraft License";
+        } else {
+            return error;
+        }
+    }
+
+    @Override
+    public String getErrorMessage() {
+        String message = super.getErrorMessage();
+
+        if (this.availableProfiles != null && this.availableProfiles.length == 0 && (message == null || message.isEmpty())) {
+            return "This Mojang account has no purchased copies of Minecraft attached.";
+        } else {
+            return message;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "AuthResponse{" +
+                "accessToken='" + accessToken + '\'' +
+                ", clientToken='" + clientToken + '\'' +
+                ", availableProfiles=" + Arrays.toString(availableProfiles) +
+                ", selectedProfile=" + selectedProfile +
+                '}';
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/auth/AuthenticationService.java
+++ b/src/main/java/net/technicpack/launchercore/auth/AuthenticationService.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.auth;
+
+import net.technicpack.launchercore.exception.AuthenticationNetworkFailureException;
+import net.technicpack.launchercore.install.user.User;
+import net.technicpack.launchercore.util.Utils;
+import org.apache.commons.io.IOUtils;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class AuthenticationService {
+    private static final String AUTH_SERVER = "https://authserver.mojang.com/";
+
+    public static AuthResponse requestRefresh(User user) throws AuthenticationNetworkFailureException {
+        RefreshRequest refreshRequest = new RefreshRequest(user.getAccessToken(), user.getClientToken());
+        String data = Utils.getMojangGson().toJson(refreshRequest);
+
+        AuthResponse response;
+        try {
+            String returned = postJson(AUTH_SERVER + "refresh", data);
+            System.out.println(returned);
+            response = Utils.getMojangGson().fromJson(returned, AuthResponse.class);
+        } catch (IOException e) {
+            throw new AuthenticationNetworkFailureException(e);
+        }
+
+        return response;
+    }
+
+    private static String postJson(String url, String data) throws IOException {
+        byte[] rawData = data.getBytes("UTF-8");
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.setUseCaches(false);
+        connection.setDoOutput(true);
+        connection.setDoInput(true);
+        connection.setConnectTimeout(15000);
+        connection.setReadTimeout(15000);
+        connection.setRequestMethod("POST");
+        connection.setRequestProperty("Content-Type", "application/json; charset=utf-8");
+        connection.setRequestProperty("Content-Length", rawData.length + "");
+        connection.setRequestProperty("Content-Language", "en-US");
+
+        DataOutputStream writer = new DataOutputStream(connection.getOutputStream());
+        writer.write(rawData);
+        writer.flush();
+        writer.close();
+
+        InputStream stream = null;
+        String returnable = null;
+        try {
+            stream = connection.getInputStream();
+            returnable = IOUtils.toString(stream);
+        } catch (IOException e) {
+            stream = connection.getErrorStream();
+
+            if (stream == null) {
+                throw e;
+            }
+        } finally {
+            try {
+                if (stream != null)
+                    stream.close();
+            } catch (IOException e) {
+            }
+        }
+
+        return returnable;
+    }
+
+    public static AuthResponse requestLogin(String username, String password, String clientToken) throws AuthenticationNetworkFailureException {
+        Agent agent = new Agent("Minecraft", "1");
+
+        AuthRequest request = new AuthRequest(agent, username, password, clientToken);
+        String data = Utils.getMojangGson().toJson(request);
+
+        AuthResponse response;
+        try {
+            String returned = postJson(AUTH_SERVER + "authenticate", data);
+            System.out.println("Auth: " + returned);
+            response = Utils.getMojangGson().fromJson(returned, AuthResponse.class);
+        } catch (IOException e) {
+            throw new AuthenticationNetworkFailureException(e);
+        }
+        return response;
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/auth/IAuthListener.java
+++ b/src/main/java/net/technicpack/launchercore/auth/IAuthListener.java
@@ -19,6 +19,15 @@
 
 package net.technicpack.launchercore.auth;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/auth/IAuthListener.java
 public interface IAuthListener<UserType> {
 	void userChanged(UserType user);
+=======
+public class ValidateRequest {
+    private String accessToken;
+
+    public ValidateRequest(String accessToken) {
+        this.accessToken = accessToken;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/auth/ValidateRequest.java
 }

--- a/src/main/java/net/technicpack/launchercore/auth/IGameAuthService.java
+++ b/src/main/java/net/technicpack/launchercore/auth/IGameAuthService.java
@@ -19,6 +19,7 @@
 
 package net.technicpack.launchercore.auth;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/auth/IGameAuthService.java
 import net.technicpack.launchercore.exception.AuthenticationNetworkFailureException;
 
 public interface IGameAuthService<UserData> {
@@ -26,4 +27,31 @@ public interface IGameAuthService<UserData> {
     public UserData createOfflineUser(String displayName);
     public IAuthResponse requestRefresh(UserData user) throws AuthenticationNetworkFailureException;
     public IAuthResponse requestLogin(String username, String password, String data) throws AuthenticationNetworkFailureException;
+=======
+public class Response {
+    private String error;
+    private String errorMessage;
+    private String cause;
+
+    public String getError() {
+        return error;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public String getCause() {
+        return cause;
+    }
+
+    @Override
+    public String toString() {
+        return "Response{" +
+                "error='" + error + '\'' +
+                ", errorMessage='" + errorMessage + '\'' +
+                ", cause='" + cause + '\'' +
+                '}';
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/auth/Response.java
 }

--- a/src/main/java/net/technicpack/launchercore/auth/IUserStore.java
+++ b/src/main/java/net/technicpack/launchercore/auth/IUserStore.java
@@ -19,6 +19,7 @@
 
 package net.technicpack.launchercore.auth;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/auth/IUserStore.java
 import java.util.Collection;
 
 public interface IUserStore<UserType> {
@@ -33,4 +34,18 @@ public interface IUserStore<UserType> {
 
 	void setLastUser(String username);
 	String getLastUser();
+=======
+public class RefreshRequest extends Response {
+    private String accessToken;
+    private String clientToken;
+
+    public RefreshRequest() {
+
+    }
+
+    public RefreshRequest(String accessToken, String clientToken) {
+        this.accessToken = accessToken;
+        this.clientToken = clientToken;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/auth/RefreshRequest.java
 }

--- a/src/main/java/net/technicpack/launchercore/auth/IUserType.java
+++ b/src/main/java/net/technicpack/launchercore/auth/IUserType.java
@@ -19,7 +19,18 @@
 
 package net.technicpack.launchercore.auth;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/auth/IUserType.java
 public interface IUserType {
     public String getUsername();
     public String getDisplayName();
+=======
+public class Agent {
+    private String name;
+    private String version;
+
+    public Agent(String name, String version) {
+        this.name = name;
+        this.version = version;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/auth/Agent.java
 }

--- a/src/main/java/net/technicpack/launchercore/auth/User.java
+++ b/src/main/java/net/technicpack/launchercore/auth/User.java
@@ -1,0 +1,20 @@
+package net.technicpack.launchercore.auth;
+
+import com.google.gson.JsonObject;
+
+public class User {
+    private String id;
+    private JsonObject userProperties;
+
+    public User() {
+
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public JsonObject getUserProperties() {
+        return userProperties;
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/exception/AuthenticationNetworkFailureException.java
+++ b/src/main/java/net/technicpack/launchercore/exception/AuthenticationNetworkFailureException.java
@@ -22,9 +22,10 @@ package net.technicpack.launchercore.exception;
 import java.io.IOException;
 
 public class AuthenticationNetworkFailureException extends IOException {
-	private Throwable cause;
+    private Throwable cause;
     private static final long serialVersionUID = 5887385045789342851L;
 
+<<<<<<< HEAD
     private String targetSite;
 
 	public AuthenticationNetworkFailureException(String targetSite) {
@@ -47,4 +48,23 @@ public class AuthenticationNetworkFailureException extends IOException {
 	}
 
     public String getTargetSite() { return targetSite; }
+=======
+    public AuthenticationNetworkFailureException() {
+
+    }
+
+    public AuthenticationNetworkFailureException(Throwable cause) {
+        this.cause = cause;
+    }
+
+    @Override
+    public String getMessage() {
+        return "An error was raised while attempting to communicate with auth.minecraft.net.";
+    }
+
+    @Override
+    public synchronized Throwable getCause() {
+        return cause;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.
 }

--- a/src/main/java/net/technicpack/launchercore/exception/BuildInaccessibleException.java
+++ b/src/main/java/net/technicpack/launchercore/exception/BuildInaccessibleException.java
@@ -22,38 +22,38 @@ package net.technicpack.launchercore.exception;
 import java.io.IOException;
 
 public class BuildInaccessibleException extends IOException {
-	private String packDisplayName;
-	private String build;
-	private Throwable cause;
+    private String packDisplayName;
+    private String build;
+    private Throwable cause;
     private static final long serialVersionUID = -4905270588640056830L;
 
-	public BuildInaccessibleException(String displayName, String build) {
-		this.packDisplayName = displayName;
-		this.build = build;
-	}
+    public BuildInaccessibleException(String displayName, String build) {
+        this.packDisplayName = displayName;
+        this.build = build;
+    }
 
-	public BuildInaccessibleException(String displayName, String build, Throwable cause) {
-		this(displayName, build);
-		this.cause = cause;
-	}
+    public BuildInaccessibleException(String displayName, String build, Throwable cause) {
+        this(displayName, build);
+        this.cause = cause;
+    }
 
-	@Override
-	public String getMessage() {
-		if (this.cause != null) {
-			Throwable rootCause = this.cause;
+    @Override
+    public String getMessage() {
+        if (this.cause != null) {
+            Throwable rootCause = this.cause;
 
-			while (rootCause.getCause() != null) {
-				rootCause = rootCause.getCause();
-			}
+            while (rootCause.getCause() != null) {
+                rootCause = rootCause.getCause();
+            }
 
-			return "An error was raised while attempting to read pack info for modpack "+packDisplayName+", build "+build+": "+rootCause.getMessage();
-		} else {
-			return "The pack host returned unrecognizable garbage while attempting to read pack info for modpack "+packDisplayName+", build "+build+".";
-		}
-	}
+            return "An error was raised while attempting to read pack info for modpack " + packDisplayName + ", build " + build + ": " + rootCause.getMessage();
+        } else {
+            return "The pack host returned unrecognizable garbage while attempting to read pack info for modpack " + packDisplayName + ", build " + build + ".";
+        }
+    }
 
-	@Override
-	public synchronized Throwable getCause() {
-		return cause;
-	}
+    @Override
+    public synchronized Throwable getCause() {
+        return cause;
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/exception/CacheDeleteException.java
+++ b/src/main/java/net/technicpack/launchercore/exception/CacheDeleteException.java
@@ -22,30 +22,30 @@ package net.technicpack.launchercore.exception;
 import java.io.IOException;
 
 public class CacheDeleteException extends IOException {
-	private Throwable cause;
-	String filePath;
+    private Throwable cause;
+    String filePath;
     private static final long serialVersionUID = 6462027370292375448L;
 
-	public CacheDeleteException(String filePath) {
-		this.filePath = filePath;
-	}
+    public CacheDeleteException(String filePath) {
+        this.filePath = filePath;
+    }
 
-	public CacheDeleteException(String filePath, Throwable cause) {
-		this.filePath = filePath;
-		this.cause = cause;
-	}
+    public CacheDeleteException(String filePath, Throwable cause) {
+        this.filePath = filePath;
+        this.cause = cause;
+    }
 
-	public String getFilePath() {
-		return this.filePath;
-	}
+    public String getFilePath() {
+        return this.filePath;
+    }
 
-	@Override
-	public synchronized Throwable getCause() {
-		return this.cause;
-	}
+    @Override
+    public synchronized Throwable getCause() {
+        return this.cause;
+    }
 
-	@Override
-	public String getMessage() {
-		return "An error occurred while attempting to delete '"+filePath+"' from the cache:";
-	}
+    @Override
+    public String getMessage() {
+        return "An error occurred while attempting to delete '" + filePath + "' from the cache:";
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/exception/DownloadException.java
+++ b/src/main/java/net/technicpack/launchercore/exception/DownloadException.java
@@ -20,38 +20,37 @@
 package net.technicpack.launchercore.exception;
 
 import java.io.IOException;
-import java.net.URL;
 
 public class DownloadException extends IOException {
-	private static final long serialVersionUID = 2L;
+    private static final long serialVersionUID = 2L;
 
-	private final Throwable cause;
-	private final String message;
+    private final Throwable cause;
+    private final String message;
 
-	public DownloadException(String message, Throwable cause) {
-		this.cause = cause;
-		this.message = message;
-	}
+    public DownloadException(String message, Throwable cause) {
+        this.cause = cause;
+        this.message = message;
+    }
 
-	public DownloadException(Throwable cause) {
-		this(null, cause);
-	}
+    public DownloadException(Throwable cause) {
+        this(null, cause);
+    }
 
-	public DownloadException(String message) {
-		this(message, null);
-	}
+    public DownloadException(String message) {
+        this(message, null);
+    }
 
-	public DownloadException() {
-		this(null, null);
-	}
+    public DownloadException() {
+        this(null, null);
+    }
 
-	@Override
-	public synchronized Throwable getCause() {
-		return this.cause;
-	}
+    @Override
+    public synchronized Throwable getCause() {
+        return this.cause;
+    }
 
-	@Override
-	public String getMessage() {
-		return message;
-	}
+    @Override
+    public String getMessage() {
+        return message;
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/exception/PackNotAvailableOfflineException.java
+++ b/src/main/java/net/technicpack/launchercore/exception/PackNotAvailableOfflineException.java
@@ -22,26 +22,26 @@ package net.technicpack.launchercore.exception;
 import java.io.IOException;
 
 public class PackNotAvailableOfflineException extends IOException {
-	private String packDisplayName;
-	private Throwable cause;
+    private String packDisplayName;
+    private Throwable cause;
     private static final long serialVersionUID = 3246491999503435492L;
 
-	public PackNotAvailableOfflineException(String displayName) {
-		this.packDisplayName = displayName;
-	}
+    public PackNotAvailableOfflineException(String displayName) {
+        this.packDisplayName = displayName;
+    }
 
-	public PackNotAvailableOfflineException(String displayName, Throwable cause) {
-		this.packDisplayName = displayName;
-		this.cause = cause;
-	}
+    public PackNotAvailableOfflineException(String displayName, Throwable cause) {
+        this.packDisplayName = displayName;
+        this.cause = cause;
+    }
 
-	@Override
-	public String getMessage() {
-		return "The modpack " + packDisplayName + " does not appear to be installed or is corrupt, and is not available for Offline Play.";
-	}
+    @Override
+    public String getMessage() {
+        return "The modpack " + packDisplayName + " does not appear to be installed or is corrupt, and is not available for Offline Play.";
+    }
 
-	@Override
-	public synchronized Throwable getCause() {
-		return cause;
-	}
+    @Override
+    public synchronized Throwable getCause() {
+        return cause;
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/exception/PermissionDeniedException.java
+++ b/src/main/java/net/technicpack/launchercore/exception/PermissionDeniedException.java
@@ -19,24 +19,22 @@
 
 package net.technicpack.launchercore.exception;
 
-import java.net.URL;
-
 public class PermissionDeniedException extends DownloadException {
-	private static final long serialVersionUID = 2L;
+    private static final long serialVersionUID = 2L;
 
-	public PermissionDeniedException(String message, Throwable cause) {
-		super(message, cause);
-	}
+    public PermissionDeniedException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
-	public PermissionDeniedException(Throwable cause) {
-		this(null, cause);
-	}
+    public PermissionDeniedException(Throwable cause) {
+        this(null, cause);
+    }
 
-	public PermissionDeniedException(String message) {
-		this(message, null);
-	}
+    public PermissionDeniedException(String message) {
+        this(message, null);
+    }
 
-	public PermissionDeniedException() {
-		this(null, null);
-	}
+    public PermissionDeniedException() {
+        this(null, null);
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/image/ImageRepository.java
+++ b/src/main/java/net/technicpack/launchercore/image/ImageRepository.java
@@ -22,6 +22,7 @@ package net.technicpack.launchercore.image;
 import java.util.HashMap;
 import java.util.Map;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/image/ImageRepository.java
 public class ImageRepository<T> {
     private IImageMapper<T> mapper;
     private IImageStore<T> store;
@@ -47,5 +48,32 @@ public class ImageRepository<T> {
             job.start(key);
 
         return job;
+=======
+public enum ReleaseType {
+    SNAPSHOT("snapshot"),
+    RELEASE("release"),
+    OLD_BETA("old-beta"),
+    OLD_ALPHA("old-alpha");
+
+    private static final Map<String, ReleaseType> lookup = new HashMap<String, ReleaseType>();
+    private final String name;
+
+    private ReleaseType(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static ReleaseType get(String name) {
+        return lookup.get(name);
+    }
+
+    static {
+        for (ReleaseType type : values()) {
+            lookup.put(type.getName(), type);
+        }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/minecraft/ReleaseType.java
     }
 }

--- a/src/main/java/net/technicpack/launchercore/install/AddPack.java
+++ b/src/main/java/net/technicpack/launchercore/install/AddPack.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.install;
+
+import net.technicpack.launchercore.util.ResourceUtils;
+
+import java.awt.image.BufferedImage;
+
+public class AddPack extends InstalledPack {
+    private final static BufferedImage icon = ResourceUtils.getImage("icon.png", 32, 32);
+    private final static BufferedImage logo = ResourceUtils.getImage("addNewPack.png", 180, 110);
+    private final static BufferedImage background = ResourceUtils.getImage("background.jpg", 880, 520);
+
+    public AddPack() {
+        super();
+    }
+
+    @Override
+    public synchronized BufferedImage getIcon() {
+        return icon;
+    }
+
+    @Override
+    public synchronized BufferedImage getBackground() {
+        return background;
+    }
+
+    @Override
+    public synchronized BufferedImage getLogo() {
+        return logo;
+    }
+
+    @Override
+    public String getName() {
+        return "addpack";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Add Pack";
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/AvailablePackList.java
+++ b/src/main/java/net/technicpack/launchercore/install/AvailablePackList.java
@@ -1,0 +1,277 @@
+package net.technicpack.launchercore.install;
+
+import net.technicpack.launchercore.exception.RestfulAPIException;
+import net.technicpack.launchercore.install.user.IAuthListener;
+import net.technicpack.launchercore.install.user.User;
+import net.technicpack.launchercore.mirror.MirrorStore;
+import net.technicpack.launchercore.restful.PackInfo;
+import net.technicpack.launchercore.restful.RestObject;
+import net.technicpack.launchercore.restful.platform.PlatformPackInfo;
+import net.technicpack.launchercore.restful.solder.FullModpacks;
+import net.technicpack.launchercore.restful.solder.Solder;
+import net.technicpack.launchercore.restful.solder.SolderConstants;
+import net.technicpack.launchercore.restful.solder.SolderPackInfo;
+import net.technicpack.launchercore.util.Utils;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Level;
+
+public class AvailablePackList implements IAuthListener, PackRefreshListener {
+    private IPackStore mPackStore;
+    private Collection<String> mForcedSolderPacks = new ArrayList<String>();
+    private List<IPackListener> mPackListeners = new LinkedList<IPackListener>();
+    private final MirrorStore mirrorStore;
+
+    public AvailablePackList(IPackStore packStore, MirrorStore mirrorStore) {
+        this.mPackStore = packStore;
+        this.mirrorStore = mirrorStore;
+        this.mPackStore.put(new AddPack());
+    }
+
+    public void addForcedSolderPack(String solderLocation) {
+        mForcedSolderPacks.add(solderLocation);
+    }
+
+    @Override
+    public void userChanged(User user) {
+        if (user == null) {
+            return;
+        }
+
+        reloadAllPacks(user);
+    }
+
+    public void addPackListener(IPackListener listener) {
+        mPackListeners.add(listener);
+    }
+
+    public void removePackListener(IPackListener listener) {
+        mPackListeners.remove(listener);
+    }
+
+    public void triggerUpdateListeners(InstalledPack pack) {
+        for (IPackListener listener : mPackListeners) {
+            listener.updatePack(pack);
+        }
+    }
+
+    @Override
+    public void refreshPack(InstalledPack pack) {
+        final InstalledPack threadPack = pack;
+        final AvailablePackList packList = this;
+        EventQueue.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                packList.triggerUpdateListeners(threadPack);
+            }
+        });
+    }
+
+    public void add(InstalledPack pack) {
+        mPackStore.add(pack);
+        mPackStore.save();
+        pack.setRefreshListener(this);
+        triggerUpdateListeners(pack);
+    }
+
+    public void put(InstalledPack pack) {
+        mPackStore.put(pack);
+        mPackStore.save();
+        pack.setRefreshListener(this);
+        triggerUpdateListeners(pack);
+    }
+
+    public void remove(InstalledPack pack) {
+        mPackStore.remove(pack.getName());
+        mPackStore.save();
+    }
+
+    public InstalledPack getOffsetPack(int offset) {
+        int index = mPackStore.getSelectedIndex();
+
+        index += offset;
+
+        int size = mPackStore.getPackNames().size();
+
+        while (index < 0) {
+            index += size;
+        }
+        while (index >= size) {
+            index -= size;
+        }
+
+        return mPackStore.getInstalledPacks().get(mPackStore.getPackNames().get(index));
+    }
+
+    public void setPack(InstalledPack pack) {
+
+        int index = mPackStore.getPackNames().indexOf(pack.getName());
+
+        if (index >= 0) {
+            mPackStore.setSelectedIndex(index);
+            mPackStore.save();
+        }
+    }
+
+    public void save() {
+        mPackStore.save();
+    }
+
+    public void reloadAllPacks(User user) {
+        final User threadUser = user;
+        final AvailablePackList packList = this;
+
+        for (final String packName : mPackStore.getPackNames()) {
+            final InstalledPack pack = mPackStore.getInstalledPacks().get(packName);
+            if (pack.isPlatform()) {
+                Thread thread = new Thread(pack.getName() + " Info Loading Thread") {
+                    @Override
+                    public void run() {
+                        try {
+                            String name = pack.getName();
+                            PlatformPackInfo platformPackInfo = PlatformPackInfo.getPlatformPackInfo(name);
+                            PackInfo info = platformPackInfo;
+                            if (platformPackInfo.hasSolder()) {
+                                info = SolderPackInfo.getSolderPackInfo(platformPackInfo.getSolder(), name, threadUser);
+                            }
+
+                            info.getLogo();
+                            info.getIcon();
+                            info.getBackground();
+                            pack.setInfo(info);
+                            pack.setRefreshListener(packList);
+                        } catch (RestfulAPIException e) {
+                            Utils.getLogger().log(Level.WARNING, "Unable to load platform pack " + pack.getName(), e);
+                            pack.setLocalOnly();
+                            pack.setRefreshListener(packList);
+                        }
+
+                        EventQueue.invokeLater(new Runnable() {
+                            @Override
+                            public void run() {
+                                packList.triggerUpdateListeners(pack);
+                            }
+                        });
+                    }
+                };
+
+                thread.start();
+            }
+        }
+
+        Thread thread = new Thread("Technic Solder Defaults") {
+            @Override
+            public void run() {
+                int index = 0;
+
+                try {
+                    FullModpacks technic = RestObject.getRestObject(FullModpacks.class, SolderConstants.getFullSolderUrl(SolderConstants.TECHNIC, threadUser.getProfile().getName()));
+                    Solder solder = new Solder(SolderConstants.TECHNIC, technic.getMirrorUrl());
+                    for (SolderPackInfo info : technic.getModpacks().values()) {
+                        String name = info.getName();
+                        info.setSolder(solder);
+
+                        InstalledPack pack = null;
+                        if (mPackStore.getInstalledPacks().containsKey(name)) {
+                            pack = mPackStore.getInstalledPacks().get(info.getName());
+                            pack.setRefreshListener(packList);
+                            pack.setInfo(info);
+
+                            final InstalledPack deferredPack = pack;
+                            final int deferredIndex = index;
+                            EventQueue.invokeLater(new Runnable() {
+                                @Override
+                                public void run() {
+                                    packList.triggerUpdateListeners(deferredPack);
+                                    mPackStore.reorder(deferredIndex, deferredPack.getName());
+                                }
+                            });
+                        } else {
+                            pack = new InstalledPack(mirrorStore, name, false);
+                            pack.setRefreshListener(packList);
+                            pack.setInfo(info);
+
+                            final InstalledPack deferredPack = pack;
+                            final int deferredIndex = index;
+                            EventQueue.invokeLater(new Runnable() {
+                                @Override
+                                public void run() {
+                                    mPackStore.add(deferredPack);
+                                    packList.triggerUpdateListeners(deferredPack);
+                                    mPackStore.reorder(deferredIndex, deferredPack.getName());
+                                }
+                            });
+                        }
+
+
+                        index++;
+                    }
+                } catch (RestfulAPIException e) {
+                    Utils.getLogger().log(Level.WARNING, "Unable to load technic modpacks", e);
+
+                    for (String packName : mPackStore.getPackNames()) {
+                        InstalledPack pack = mPackStore.getInstalledPacks().get(packName);
+                        if (!pack.isPlatform() && pack.getInfo() == null && pack.getName() != null)
+                            pack.setLocalOnly();
+                    }
+                }
+            }
+        };
+        thread.start();
+
+        thread = new Thread("Forced Solder Thread") {
+
+            @Override
+            public void run() {
+                for (String solder : mForcedSolderPacks) {
+                    try {
+                        SolderPackInfo info = SolderPackInfo.getSolderPackInfo(solder);
+                        if (info == null) {
+                            throw new RestfulAPIException();
+                        }
+
+                        info.getLogo();
+                        info.getIcon();
+                        info.getBackground();
+
+                        InstalledPack pack = null;
+                        if (mPackStore.getInstalledPacks().containsKey(info.getName())) {
+                            pack = mPackStore.getInstalledPacks().get(info.getName());
+                            pack.setInfo(info);
+
+                            final InstalledPack deferredPack = pack;
+                            EventQueue.invokeLater(new Runnable() {
+                                @Override
+                                public void run() {
+                                    packList.triggerUpdateListeners(deferredPack);
+                                }
+                            });
+                        } else {
+                            pack = new InstalledPack(mirrorStore, info.getName(), true);
+                            pack.setRefreshListener(packList);
+                            pack.setInfo(info);
+
+                            final InstalledPack deferredPack = pack;
+                            EventQueue.invokeLater(new Runnable() {
+                                @Override
+                                public void run() {
+                                    mPackStore.add(deferredPack);
+                                    packList.triggerUpdateListeners(deferredPack);
+                                }
+                            });
+                        }
+
+                    } catch (RestfulAPIException e) {
+                        Utils.getLogger().log(Level.WARNING, "Unable to load forced solder pack " + solder, e);
+                    }
+                }
+            }
+        };
+
+        thread.start();
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/IPackListener.java
+++ b/src/main/java/net/technicpack/launchercore/install/IPackListener.java
@@ -1,0 +1,5 @@
+package net.technicpack.launchercore.install;
+
+public interface IPackListener {
+    void updatePack(InstalledPack pack);
+}

--- a/src/main/java/net/technicpack/launchercore/install/IPackStore.java
+++ b/src/main/java/net/technicpack/launchercore/install/IPackStore.java
@@ -1,0 +1,24 @@
+package net.technicpack.launchercore.install;
+
+import java.util.List;
+import java.util.Map;
+
+public interface IPackStore {
+    Map<String, InstalledPack> getInstalledPacks();
+
+    List<String> getPackNames();
+
+    int getSelectedIndex();
+
+    void setSelectedIndex(int index);
+
+    void reorder(int index, String pack);
+
+    InstalledPack add(InstalledPack installedPack);
+
+    InstalledPack put(InstalledPack installedPack);
+
+    InstalledPack remove(String name);
+
+    void save();
+}

--- a/src/main/java/net/technicpack/launchercore/install/ITasksQueue.java
+++ b/src/main/java/net/technicpack/launchercore/install/ITasksQueue.java
@@ -19,9 +19,23 @@
 
 package net.technicpack.launchercore.install;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/install/ITasksQueue.java
 import net.technicpack.launchercore.install.tasks.IInstallTask;
 
 public interface ITasksQueue {
     void addNextTask(IInstallTask task);
     void addTask(IInstallTask task);
+=======
+public class LatestEntry {
+    private String snapshot;
+    private String release;
+
+    public String getSnapshot() {
+        return snapshot;
+    }
+
+    public String getRelease() {
+        return release;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/minecraft/versionlist/LatestEntry.java
 }

--- a/src/main/java/net/technicpack/launchercore/install/IVersionDataParser.java
+++ b/src/main/java/net/technicpack/launchercore/install/IVersionDataParser.java
@@ -19,6 +19,12 @@
 
 package net.technicpack.launchercore.install;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/install/IVersionDataParser.java
 public interface IVersionDataParser<VersionData> {
     VersionData parseVersionData(String data);
+=======
+public interface PackRefreshListener {
+
+    public void refreshPack(InstalledPack pack);
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/install/PackRefreshListener.java
 }

--- a/src/main/java/net/technicpack/launchercore/install/InstalledPack.java
+++ b/src/main/java/net/technicpack/launchercore/install/InstalledPack.java
@@ -1,0 +1,405 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.install;
+
+import net.technicpack.launchercore.mirror.MirrorStore;
+import net.technicpack.launchercore.mirror.download.Download;
+import net.technicpack.launchercore.restful.PackInfo;
+import net.technicpack.launchercore.restful.Resource;
+import net.technicpack.launchercore.util.MD5Utils;
+import net.technicpack.launchercore.util.ResourceUtils;
+import net.technicpack.launchercore.util.Utils;
+import org.apache.commons.io.FileUtils;
+
+import javax.imageio.IIOException;
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+
+public class InstalledPack {
+    public static final String RECOMMENDED = "recommended";
+    public static final String LATEST = "latest";
+    public static final String LAUNCHER_DIR = "launcher\\";
+    public static final String MODPACKS_DIR = "%MODPACKS%\\";
+
+    private static BufferedImage BACKUP_LOGO;
+    private static BufferedImage BACKUP_BACKGROUND;
+    private static BufferedImage BACKUP_ICON;
+    private transient AtomicReference<BufferedImage> logo = new AtomicReference<BufferedImage>();
+    private transient AtomicReference<BufferedImage> background = new AtomicReference<BufferedImage>();
+    private transient AtomicReference<BufferedImage> icon = new AtomicReference<BufferedImage>();
+    private transient HashMap<AtomicReference<BufferedImage>, AtomicReference<Boolean>> downloading = new HashMap<AtomicReference<BufferedImage>, AtomicReference<Boolean>>(3);
+    private transient File installedDirectory;
+    private transient File binDir;
+    private transient File configDir;
+    private transient File savesDir;
+    private transient File cacheDir;
+    private transient File resourceDir;
+    private transient File modsDir;
+    private transient File coremodsDir;
+    private transient PackInfo info;
+    private transient PackRefreshListener refreshListener;
+    private transient MirrorStore mirrorStore;
+    private String name;
+    private boolean platform;
+    private String build;
+    private String directory;
+
+    private transient boolean isLocalOnly;
+
+    public InstalledPack(MirrorStore mirrorStore, String name, boolean platform, String build, String directory) {
+        this();
+        this.mirrorStore = mirrorStore;
+        this.name = name;
+        this.platform = platform;
+        this.build = build;
+        this.directory = directory;
+    }
+
+    public InstalledPack(MirrorStore mirrorStore, String name, boolean platform) {
+        this(mirrorStore, name, platform, RECOMMENDED, MODPACKS_DIR + name);
+    }
+
+    public InstalledPack() {
+        downloading.put(logo, new AtomicReference<Boolean>(false));
+        downloading.put(background, new AtomicReference<Boolean>(false));
+        downloading.put(icon, new AtomicReference<Boolean>(false));
+        isLocalOnly = false;
+        build = RECOMMENDED;
+    }
+
+    public void setMirrorStore(MirrorStore mirrorStore) {
+        this.mirrorStore = mirrorStore;
+    }
+
+    public void setRefreshListener(PackRefreshListener refreshListener) {
+        this.refreshListener = refreshListener;
+    }
+
+    public String getDirectory() {
+        String path = directory;
+        if (directory != null && directory.startsWith(LAUNCHER_DIR)) {
+            path = new File(Utils.getLauncherDirectory(), directory.substring(9)).getAbsolutePath();
+        }
+        if (directory != null && directory.startsWith(MODPACKS_DIR)) {
+            path = new File(Utils.getModpacksDirectory(), directory.substring(11)).getAbsolutePath();
+        }
+        return path;
+    }
+
+    public void initDirectories() {
+        binDir = new File(installedDirectory, "bin");
+        configDir = new File(installedDirectory, "config");
+        savesDir = new File(installedDirectory, "saves");
+        cacheDir = new File(installedDirectory, "cache");
+        resourceDir = new File(installedDirectory, "resources");
+        modsDir = new File(installedDirectory, "mods");
+        coremodsDir = new File(installedDirectory, "coremods");
+
+        binDir.mkdirs();
+        configDir.mkdirs();
+        savesDir.mkdirs();
+        cacheDir.mkdirs();
+        resourceDir.mkdirs();
+        modsDir.mkdirs();
+        coremodsDir.mkdirs();
+    }
+
+    public String getDisplayName() {
+        if (info == null) {
+            return name;
+        }
+        return info.getDisplayName();
+    }
+
+    public boolean isPlatform() {
+        return platform;
+    }
+
+    public PackInfo getInfo() {
+        return info;
+    }
+
+    public void setInfo(PackInfo info) {
+        this.info = info;
+        this.isLocalOnly = false;
+    }
+
+    public boolean isLocalOnly() {
+        return isLocalOnly;
+    }
+
+    public void setLocalOnly() {
+        this.isLocalOnly = true;
+    }
+
+    public boolean hasLogo() {
+        return (getLogo() != BACKUP_LOGO);
+    }
+
+    public String getBuild() {
+        if (info != null) {
+            if (build.equals(RECOMMENDED)) {
+                return info.getRecommended();
+            }
+            if (build.equals(LATEST)) {
+                return info.getLatest();
+            }
+        }
+
+        return build;
+    }
+
+    public void setBuild(String build) {
+        this.build = build;
+    }
+
+    public String getRawBuild() {
+        return build;
+    }
+
+    public File getInstalledDirectory() {
+        if (installedDirectory == null) {
+            setPackDirectory(new File(getDirectory()));
+        }
+        return installedDirectory;
+    }
+
+    public void setPackDirectory(File packPath) {
+        if (installedDirectory != null) {
+            try {
+                FileUtils.copyDirectory(installedDirectory, packPath);
+                FileUtils.cleanDirectory(installedDirectory);
+            } catch (IOException e) {
+                e.printStackTrace();
+                return;
+            }
+        }
+        installedDirectory = packPath;
+        String path = installedDirectory.getAbsolutePath();
+        if (path.equals(Utils.getModpacksDirectory().getAbsolutePath())) {
+            directory = MODPACKS_DIR;
+        } else if (path.equals(Utils.getLauncherDirectory().getAbsolutePath())) {
+            directory = LAUNCHER_DIR;
+        } else if (path.startsWith(Utils.getModpacksDirectory().getAbsolutePath())) {
+            directory = MODPACKS_DIR + path.substring(Utils.getModpacksDirectory().getAbsolutePath().length() + 1);
+        } else if (path.startsWith(Utils.getLauncherDirectory().getAbsolutePath())) {
+            directory = LAUNCHER_DIR + path.substring(Utils.getLauncherDirectory().getAbsolutePath().length() + 1);
+        }
+        initDirectories();
+    }
+
+    public File getBinDir() {
+        return binDir;
+    }
+
+    public File getConfigDir() {
+        return configDir;
+    }
+
+    public File getSavesDir() {
+        return savesDir;
+    }
+
+    public File getCacheDir() {
+        return cacheDir;
+    }
+
+    public File getResourceDir() {
+        return resourceDir;
+    }
+
+    public File getModsDir() {
+        return modsDir;
+    }
+
+    public File getCoremodsDir() {
+        return coremodsDir;
+    }
+
+    public synchronized BufferedImage getLogo() {
+        if (logo.get() != null) {
+            return logo.get();
+        } else {
+            Resource resource = info != null ? info.getLogo() : null;
+            if (loadImage(logo, "logo.png", resource)) {
+                return logo.get();
+            }
+        }
+
+        if (BACKUP_LOGO == null) {
+            BACKUP_LOGO = loadBackup("/org/spoutcraft/launcher/resources/noLogo.png");
+        }
+        return BACKUP_LOGO;
+    }
+
+    private boolean loadImage(AtomicReference<BufferedImage> image, String name, Resource resource) {
+        File assets = new File(Utils.getAssetsDirectory(), "packs");
+        File packs = new File(assets, getName());
+        packs.mkdirs();
+        File resourceFile = new File(packs, name);
+
+        String url = "";
+        String md5 = "";
+
+        if (resource != null) {
+            url = resource.getUrl();
+            md5 = resource.getMd5();
+        }
+
+        boolean cached = loadCachedImage(image, resourceFile, url, md5);
+
+        if (!cached) {
+            downloadImage(image, resourceFile, url, md5);
+        }
+
+        if (image.get() == null) {
+            return false;
+        }
+
+        return cached;
+    }
+
+    private boolean loadCachedImage(AtomicReference<BufferedImage> image, File file, String url, String md5) {
+        try {
+            if (!file.exists())
+                return false;
+
+            boolean reloadImage = (url.isEmpty() || md5.isEmpty());
+
+            if (!reloadImage) {
+                String fileMd5 = MD5Utils.getMD5(file);
+
+                if (fileMd5 != null && !fileMd5.isEmpty())
+                    reloadImage = fileMd5.equalsIgnoreCase(md5);
+            }
+
+            if (reloadImage) {
+                BufferedImage newImage;
+                newImage = ImageIO.read(file);
+                image.set(newImage);
+                return true;
+            }
+        } catch (IIOException e) {
+            Utils.getLogger().log(Level.INFO, "Failed to load image " + file.getAbsolutePath() + " from file.");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return false;
+    }
+
+    private void downloadImage(final AtomicReference<BufferedImage> image, final File temp, final String url, final String md5) {
+        if (url.isEmpty() || downloading.get(image).get()) {
+            return;
+        }
+
+        downloading.get(image).set(true);
+        final String name = getName();
+        final InstalledPack pack = this;
+        final MirrorStore mirror = mirrorStore;
+        Thread thread = new Thread(name + " Image Download Worker") {
+            @Override
+            public void run() {
+                try {
+                    if (temp.exists()) {
+                        System.out.println("Pack: " + getName() + " Calculated MD5: " + MD5Utils.getMD5(temp) + " Required MD5: " + md5);
+                    }
+                    Download download = mirror.downloadFile(url, temp.getName(), temp.getAbsolutePath());
+                    BufferedImage newImage;
+                    newImage = ImageIO.read(download.getOutFile());
+                    image.set(newImage);
+                    downloading.get(image).set(false);
+                    if (refreshListener != null) {
+                        refreshListener.refreshPack(pack);
+                    }
+                } catch (IOException e) {
+                    System.out.println("Failed to download and load image from: " + url);
+                    e.printStackTrace();
+                }
+            }
+        };
+        thread.start();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    private BufferedImage loadBackup(String backup) {
+        try {
+            return ImageIO.read(ResourceUtils.getResourceAsStream(backup));
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public synchronized BufferedImage getBackground() {
+        if (background.get() != null) {
+            return background.get();
+        } else {
+            Resource resource = info != null ? info.getBackground() : null;
+            if (loadImage(background, "background.jpg", resource)) {
+                return background.get();
+            }
+        }
+
+        if (BACKUP_BACKGROUND == null) {
+            BACKUP_BACKGROUND = loadBackup("/org/spoutcraft/launcher/resources/background.jpg");
+        }
+        return BACKUP_BACKGROUND;
+    }
+
+    public synchronized BufferedImage getIcon() {
+        if (icon.get() != null) {
+            return icon.get();
+        } else {
+            Resource resource = info != null ? info.getIcon() : null;
+            if (loadImage(icon, "icon.png", resource)) {
+                return icon.get();
+            }
+        }
+
+        if (BACKUP_ICON == null) {
+            BACKUP_ICON = loadBackup("/org/spoutcraft/launcher/resources/icon.png");
+        }
+        return BACKUP_ICON;
+    }
+
+    public String getIconPath() {
+        return Utils.getAssetsDirectory() + "/packs/" + getName() + "/icon.png";
+    }
+
+    @Override
+    public String toString() {
+        return "InstalledPack{" +
+                "info=" + info +
+                ", name='" + name + '\'' +
+                ", platform=" + platform +
+                ", build='" + build + '\'' +
+                ", directory='" + directory + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/LauncherDirectories.java
+++ b/src/main/java/net/technicpack/launchercore/install/LauncherDirectories.java
@@ -21,12 +21,23 @@ package net.technicpack.launchercore.install;
 
 import java.io.File;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/install/LauncherDirectories.java
 public abstract class LauncherDirectories {
 	public abstract File getLauncherDirectory();
 
 	public abstract File getCacheDirectory();
+=======
+public abstract class Directories {
+    public static Directories instance;
 
-	public abstract File getAssetsDirectory();
+    public abstract File getLauncherDirectory();
 
-	public abstract File getModpacksDirectory();
+    public abstract File getSettingsDirectory();
+
+    public abstract File getCacheDirectory();
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/util/Directories.java
+
+    public abstract File getAssetsDirectory();
+
+    public abstract File getModpacksDirectory();
 }

--- a/src/main/java/net/technicpack/launchercore/install/ModpackInstaller.java
+++ b/src/main/java/net/technicpack/launchercore/install/ModpackInstaller.java
@@ -20,6 +20,7 @@
 package net.technicpack.launchercore.install;
 
 import net.technicpack.launchercore.exception.PackNotAvailableOfflineException;
+<<<<<<< HEAD
 import net.technicpack.launchercore.modpacks.ModpackModel;
 import net.technicpack.platform.IPlatformApi;
 
@@ -27,10 +28,28 @@ import net.technicpack.utilslib.Utils;
 import net.technicpack.utilslib.ZipUtils;
 import org.apache.commons.io.FileUtils;
 
+=======
+import net.technicpack.launchercore.install.tasks.*;
+import net.technicpack.launchercore.install.user.User;
+import net.technicpack.launchercore.minecraft.CompleteVersion;
+import net.technicpack.launchercore.mirror.MirrorStore;
+import net.technicpack.launchercore.restful.Modpack;
+import net.technicpack.launchercore.restful.PackInfo;
+import net.technicpack.launchercore.restful.PlatformConstants;
+import net.technicpack.launchercore.util.DownloadListener;
+import net.technicpack.launchercore.util.Utils;
+import net.technicpack.launchercore.util.ZipUtils;
+import net.technicpack.launchercore.util.verifiers.ValidZipFileVerifier;
+import org.apache.commons.io.FileUtils;
+
+import javax.swing.*;
+import java.awt.*;
+>>>>>>> Re-tab & optimize imports for all files in core.
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
+<<<<<<< HEAD
 public class ModpackInstaller<VersionData> {
     private final IPlatformApi platformApi;
     private final String clientId;
@@ -75,4 +94,111 @@ public class ModpackInstaller<VersionData> {
 		String json = FileUtils.readFileToString(versionFile, Charset.forName("UTF-8"));
 		return parser.parseVersionData(json);
 	}
+=======
+public class ModpackInstaller {
+    private final DownloadListener listener;
+    private final InstalledPack installedPack;
+    private String build;
+    private boolean finished = false;
+    private MirrorStore mirrorStore;
+
+    public ModpackInstaller(DownloadListener listener, InstalledPack installedPack, String build, MirrorStore mirrorStore) {
+        this.listener = listener;
+        this.installedPack = installedPack;
+        this.build = build;
+        this.mirrorStore = mirrorStore;
+    }
+
+    public CompleteVersion installPack(Component component, User user) throws IOException {
+        InstallTasksQueue queue = new InstallTasksQueue(this.listener, mirrorStore);
+        queue.AddTask(new InitPackDirectoryTask(this.installedPack));
+
+        PackInfo packInfo = this.installedPack.getInfo();
+        Modpack modpack = packInfo.getModpack(this.build, user);
+        String minecraft = modpack.getMinecraft();
+
+        if (minecraft.startsWith("1.5")) {
+            queue.AddTask(new EnsureFileTask(new File(Utils.getCacheDirectory(), "fml_libs15.zip"), new ValidZipFileVerifier(), new File(installedPack.getInstalledDirectory(), "lib"), "http://mirror.technicpack.net/Technic/lib/fml/fml_libs15.zip"));
+        } else if (minecraft.startsWith("1.4")) {
+            queue.AddTask(new EnsureFileTask(new File(Utils.getCacheDirectory(), "fml_libs.zip"), new ValidZipFileVerifier(), new File(installedPack.getInstalledDirectory(), "lib"), "http://mirror.technicpack.net/Technic/lib/fml/fml_libs.zip"));
+        }
+
+        queue.RunAllTasks();
+        Version installedVersion = this.getInstalledVersion();
+
+        boolean shouldUpdate = installedVersion == null;
+        if (!shouldUpdate && !this.build.equals(installedVersion.getVersion())) {
+            int result = JOptionPane.showConfirmDialog(component, "Would you like to update this pack?", "Update Found", JOptionPane.YES_NO_OPTION, JOptionPane.INFORMATION_MESSAGE);
+
+            if (result == JOptionPane.YES_OPTION) {
+                shouldUpdate = true;
+            } else {
+                build = installedVersion.getVersion();
+            }
+        }
+
+        if (shouldUpdate) {
+            //If we're installing a new version of modpack, then we need to get rid of the existing version.json
+            File versionFile = new File(installedPack.getBinDir(), "version.json");
+            if (versionFile.exists()) {
+                if (!versionFile.delete()) {
+                    throw new CacheDeleteException(versionFile.getAbsolutePath());
+                }
+            }
+
+            queue.AddTask(new InstallModpackTask(this.installedPack, modpack));
+        }
+
+        queue.AddTask(new VerifyVersionFilePresentTask(installedPack, minecraft));
+        queue.AddTask(new HandleVersionFileTask(installedPack));
+
+        if ((installedVersion != null && installedVersion.isLegacy()) || shouldUpdate)
+            queue.AddTask(new InstallMinecraftIfNecessaryTask(this.installedPack, minecraft));
+
+        queue.RunAllTasks();
+
+        Version versionFile = new Version(build, false);
+        versionFile.save(installedPack.getBinDir());
+
+        finished = true;
+        return queue.getCompleteVersion();
+    }
+
+    private Version getInstalledVersion() {
+        Version version = null;
+        File versionFile = new File(this.installedPack.getBinDir(), "version");
+        if (versionFile.exists()) {
+            version = Version.load(versionFile);
+        } else {
+            Utils.pingHttpURL(PlatformConstants.getDownloadCountUrl(this.installedPack.getName()), mirrorStore);
+            Utils.sendTracking("installModpack", this.installedPack.getName(), this.installedPack.getBuild());
+        }
+        return version;
+    }
+
+    public boolean isFinished() {
+        return finished;
+    }
+
+    public CompleteVersion prepareOfflinePack() throws IOException {
+        installedPack.getInstalledDirectory();
+        installedPack.initDirectories();
+
+        File versionFile = new File(installedPack.getBinDir(), "version.json");
+        File modpackJar = new File(installedPack.getBinDir(), "modpack.jar");
+
+        boolean didExtract = false;
+
+        if (modpackJar.exists()) {
+            didExtract = ZipUtils.extractFile(modpackJar, installedPack.getBinDir(), "version.json");
+        }
+
+        if (!versionFile.exists()) {
+            throw new PackNotAvailableOfflineException(installedPack.getDisplayName());
+        }
+
+        String json = FileUtils.readFileToString(versionFile, Charset.forName("UTF-8"));
+        return Utils.getMojangGson().fromJson(json, CompleteVersion.class);
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.
 }

--- a/src/main/java/net/technicpack/launchercore/install/Version.java
+++ b/src/main/java/net/technicpack/launchercore/install/Version.java
@@ -29,65 +29,65 @@ import java.nio.charset.Charset;
 import java.util.logging.Level;
 
 public class Version {
-	private String version;
-	private boolean legacy;
+    private String version;
+    private boolean legacy;
 
-	public Version() {
+    public Version() {
 
-	}
+    }
 
-	public Version(String version, boolean legacy) {
-		this.version = version;
-		this.legacy = legacy;
-	}
+    public Version(String version, boolean legacy) {
+        this.version = version;
+        this.legacy = legacy;
+    }
 
-	public boolean isLegacy() {
-		return legacy;
-	}
+    public boolean isLegacy() {
+        return legacy;
+    }
 
-	public String getVersion() {
-		return version;
-	}
+    public String getVersion() {
+        return version;
+    }
 
-	public void setVersion(String version) {
-		this.version = version;
-	}
+    public void setVersion(String version) {
+        this.version = version;
+    }
 
-	public void setLegacy(boolean legacy) {
-		this.legacy = legacy;
-	}
+    public void setLegacy(boolean legacy) {
+        this.legacy = legacy;
+    }
 
-	public static Version load(File version) {
-		if (!version.exists()) {
-			Utils.getLogger().log(Level.WARNING, "Unable to load version from " + version + " because it does not exist.");
-			return null;
-		}
+    public static Version load(File version) {
+        if (!version.exists()) {
+            Utils.getLogger().log(Level.WARNING, "Unable to load version from " + version + " because it does not exist.");
+            return null;
+        }
 
-		try {
-			String json = FileUtils.readFileToString(version, Charset.forName("UTF-8"));
-			return Utils.getGson().fromJson(json, Version.class);
-		} catch (JsonSyntaxException e) {
-			Utils.getLogger().log(Level.WARNING, "Unable to load version from " + version);
-			return null;
-		} catch (IOException e) {
-			Utils.getLogger().log(Level.WARNING, "Unable to load version from " + version);
-			return null;
-		}
-	}
+        try {
+            String json = FileUtils.readFileToString(version, Charset.forName("UTF-8"));
+            return Utils.getGson().fromJson(json, Version.class);
+        } catch (JsonSyntaxException e) {
+            Utils.getLogger().log(Level.WARNING, "Unable to load version from " + version);
+            return null;
+        } catch (IOException e) {
+            Utils.getLogger().log(Level.WARNING, "Unable to load version from " + version);
+            return null;
+        }
+    }
 
-	public void save(File saveDirectory) {
-		File version = new File(saveDirectory, "version");
-		String json = Utils.getGson().toJson(this);
+    public void save(File saveDirectory) {
+        File version = new File(saveDirectory, "version");
+        String json = Utils.getGson().toJson(this);
 
-		try {
-			FileUtils.writeStringToFile(version, json, Charset.forName("UTF-8"));
-		} catch (IOException e) {
-			Utils.getLogger().log(Level.WARNING, "Unable to save installed " + version);
-		}
-	}
+        try {
+            FileUtils.writeStringToFile(version, json, Charset.forName("UTF-8"));
+        } catch (IOException e) {
+            Utils.getLogger().log(Level.WARNING, "Unable to save installed " + version);
+        }
+    }
 
-	@Override
-	public String toString() {
-		return version + " " + legacy;
-	}
+    @Override
+    public String toString() {
+        return version + " " + legacy;
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/install/tasks/CleanupModpackCacheTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/CleanupModpackCacheTask.java
@@ -1,0 +1,54 @@
+package net.technicpack.launchercore.install.tasks;
+
+import net.technicpack.launchercore.install.InstalledPack;
+import net.technicpack.launchercore.restful.Modpack;
+import net.technicpack.launchercore.restful.solder.Mod;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class CleanupModpackCacheTask implements IInstallTask {
+    private InstalledPack pack;
+    private Modpack modpack;
+
+    public CleanupModpackCacheTask(InstalledPack pack, Modpack modpack) {
+        this.pack = pack;
+        this.modpack = modpack;
+    }
+
+    @Override
+    public String getTaskDescription() {
+        return "Cleaning Modpack Cache";
+    }
+
+    @Override
+    public float getTaskProgress() {
+        return 0;
+    }
+
+    @Override
+    public void runTask(InstallTasksQueue queue) throws IOException {
+        File[] files = this.pack.getCacheDir().listFiles();
+
+        if (files == null) {
+            return;
+        }
+
+        Set<String> keepFiles = new HashSet<String>(modpack.getMods().size() + 1);
+        for (Mod mod : modpack.getMods()) {
+            keepFiles.add(mod.getName() + "-" + mod.getVersion() + ".zip");
+        }
+        keepFiles.add("minecraft.jar");
+
+        for (File file : files) {
+            String fileName = file.getName();
+            if (keepFiles.contains(fileName)) {
+                continue;
+            }
+            FileUtils.deleteQuietly(file);
+        }
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/tasks/CopyFileTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/CopyFileTask.java
@@ -26,26 +26,26 @@ import java.io.File;
 import java.io.IOException;
 
 public class CopyFileTask implements IInstallTask {
-	private File source;
-	private File destination;
+    private File source;
+    private File destination;
 
-	public CopyFileTask(File source, File destination) {
-		this.source = source;
-		this.destination = destination;
-	}
+    public CopyFileTask(File source, File destination) {
+        this.source = source;
+        this.destination = destination;
+    }
 
-	@Override
-	public String getTaskDescription() {
-		return "Copying files.";
-	}
+    @Override
+    public String getTaskDescription() {
+        return "Copying files.";
+    }
 
-	@Override
-	public float getTaskProgress() {
-		return 0;
-	}
+    @Override
+    public float getTaskProgress() {
+        return 0;
+    }
 
-	@Override
-	public void runTask(InstallTasksQueue queue) throws IOException {
-		FileUtils.copyFile(this.source, this.destination);
-	}
+    @Override
+    public void runTask(InstallTasksQueue queue) throws IOException {
+        FileUtils.copyFile(this.source, this.destination);
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/install/tasks/DownloadFileTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/DownloadFileTask.java
@@ -20,42 +20,46 @@
 package net.technicpack.launchercore.install.tasks;
 
 import net.technicpack.launchercore.exception.DownloadException;
+<<<<<<< HEAD
 import net.technicpack.launchercore.install.InstallTasksQueue;
 import net.technicpack.launchercore.install.verifiers.IFileVerifier;
+=======
+import net.technicpack.launchercore.util.verifiers.IFileVerifier;
+>>>>>>> Re-tab & optimize imports for all files in core.
 
 import java.io.File;
 import java.io.IOException;
 
 public class DownloadFileTask extends ListenerTask {
-	private String url;
-	private File destination;
-	private String taskDescription;
+    private String url;
+    private File destination;
+    private String taskDescription;
     private IFileVerifier fileVerifier;
 
-	public DownloadFileTask(String url, File destination, IFileVerifier verifier) {
-		this(url, destination, verifier, destination.getName());
-	}
+    public DownloadFileTask(String url, File destination, IFileVerifier verifier) {
+        this(url, destination, verifier, destination.getName());
+    }
 
-	public DownloadFileTask(String url, File destination, IFileVerifier verifier, String taskDescription) {
-		this.url = url;
-		this.destination = destination;
-		this.taskDescription = taskDescription;
+    public DownloadFileTask(String url, File destination, IFileVerifier verifier, String taskDescription) {
+        this.url = url;
+        this.destination = destination;
+        this.taskDescription = taskDescription;
         this.fileVerifier = verifier;
-	}
+    }
 
-	@Override
-	public String getTaskDescription() {
-		return taskDescription;
-	}
+    @Override
+    public String getTaskDescription() {
+        return taskDescription;
+    }
 
-	@Override
-	public void runTask(InstallTasksQueue queue) throws IOException {
-		super.runTask(queue);
+    @Override
+    public void runTask(InstallTasksQueue queue) throws IOException {
+        super.runTask(queue);
 
-		queue.getMirrorStore().downloadFile(url, this.destination.getName(), this.destination.getAbsolutePath(), null, fileVerifier, this);
+        queue.getMirrorStore().downloadFile(url, this.destination.getName(), this.destination.getAbsolutePath(), null, fileVerifier, this);
 
-		if (!this.destination.exists()) {
-			throw new DownloadException("Failed to download "+this.destination.getName()+".");
-		}
-	}
+        if (!this.destination.exists()) {
+            throw new DownloadException("Failed to download " + this.destination.getName() + ".");
+        }
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/install/tasks/EnsureFileTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/EnsureFileTask.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 
 public class EnsureFileTask implements IInstallTask {
+<<<<<<< HEAD
 	private final File cacheLocation;
 	private final File zipExtractLocation;
 	private final String sourceUrl;
@@ -78,4 +79,52 @@ public class EnsureFileTask implements IInstallTask {
 		if (sourceUrl != null && (!this.cacheLocation.exists() || (fileVerifier != null && !fileVerifier.isFileValid(this.cacheLocation))))
 			downloadTaskQueue.addNextTask(new DownloadFileTask(this.sourceUrl, this.cacheLocation, this.fileVerifier, this.friendlyFileName));
 	}
+=======
+    private File cacheLocation;
+    private File zipExtractLocation;
+    private String sourceUrl;
+    private ExtractRules rules;
+    private String friendlyFileName;
+    private IFileVerifier fileVerifier;
+
+    public EnsureFileTask(File fileLocation, IFileVerifier fileVerifier, File zipExtractLocation, String sourceUrl, String friendlyFileName) {
+        this(fileLocation, fileVerifier, zipExtractLocation, sourceUrl, friendlyFileName, null);
+    }
+
+    public EnsureFileTask(File fileLocation, IFileVerifier fileVerifier, File zipExtractLocation, String sourceUrl) {
+        this(fileLocation, fileVerifier, zipExtractLocation, sourceUrl, fileLocation.getName(), null);
+    }
+
+    public EnsureFileTask(File fileLocation, IFileVerifier fileVerifier, File zipExtractLocation, String sourceUrl, ExtractRules rules) {
+        this(fileLocation, fileVerifier, zipExtractLocation, sourceUrl, fileLocation.getName(), rules);
+    }
+
+    public EnsureFileTask(File fileLocation, IFileVerifier fileVerifier, File zipExtractLocation, String sourceUrl, String friendlyFileName, ExtractRules rules) {
+        this.cacheLocation = fileLocation;
+        this.zipExtractLocation = zipExtractLocation;
+        this.sourceUrl = sourceUrl;
+        this.fileVerifier = fileVerifier;
+        this.rules = rules;
+        this.friendlyFileName = friendlyFileName;
+    }
+
+    @Override
+    public String getTaskDescription() {
+        return "Verifying " + this.cacheLocation.getName();
+    }
+
+    @Override
+    public float getTaskProgress() {
+        return 0;
+    }
+
+    @Override
+    public void runTask(InstallTasksQueue queue) throws IOException {
+        if (this.zipExtractLocation != null)
+            queue.AddNextTask(new UnzipFileTask(this.cacheLocation, this.zipExtractLocation, this.rules));
+
+        if (!this.cacheLocation.exists() || (fileVerifier != null && !fileVerifier.isFileValid(this.cacheLocation)))
+            queue.AddNextTask(new DownloadFileTask(this.sourceUrl, this.cacheLocation, this.fileVerifier, this.friendlyFileName));
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.
 }

--- a/src/main/java/net/technicpack/launchercore/install/tasks/GetAssetsIndexTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/GetAssetsIndexTask.java
@@ -1,0 +1,93 @@
+package net.technicpack.launchercore.install.tasks;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import net.technicpack.launchercore.exception.DownloadException;
+import net.technicpack.launchercore.install.InstalledPack;
+import net.technicpack.launchercore.minecraft.MojangConstants;
+import net.technicpack.launchercore.util.Utils;
+import net.technicpack.launchercore.util.verifiers.FileSizeVerifier;
+import net.technicpack.launchercore.util.verifiers.IFileVerifier;
+import net.technicpack.launchercore.util.verifiers.ValidJsonFileVerifier;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+public class GetAssetsIndexTask extends ListenerTask {
+    private InstalledPack pack;
+
+    public GetAssetsIndexTask(InstalledPack pack) {
+        this.pack = pack;
+    }
+
+    @Override
+    public String getTaskDescription() {
+        return "Retrieving assets index";
+    }
+
+    @Override
+    public void runTask(InstallTasksQueue queue) throws IOException {
+        super.runTask(queue);
+
+        String assets = queue.getCompleteVersion().getAssetsKey();
+
+        if (assets == null || assets.isEmpty()) {
+            assets = "legacy";
+        }
+
+        File output = new File(Utils.getAssetsDirectory() + File.separator + "indexes", assets + ".json");
+
+        (new File(output.getParent())).mkdirs();
+
+        IFileVerifier fileVerifier = new ValidJsonFileVerifier();
+        String assetsUrl = MojangConstants.getAssetsIndex(assets);
+
+        if (!output.exists() || !fileVerifier.isFileValid(output)) {
+            queue.getMirrorStore().downloadFile(assetsUrl, output.getName(), output.getAbsolutePath(), null, fileVerifier, this);
+        }
+
+        String json = FileUtils.readFileToString(output, Charset.forName("UTF-8"));
+        JsonObject obj = Utils.getMojangGson().fromJson(json, JsonObject.class);
+
+        if (obj == null) {
+            throw new DownloadException("The assets json file was invalid.");
+        }
+
+        boolean isVirtual = false;
+
+        if (obj.get("virtual") != null)
+            isVirtual = obj.get("virtual").getAsBoolean();
+
+        queue.getCompleteVersion().setAreAssetsVirtual(isVirtual);
+
+        JsonObject allObjects = obj.get("objects").getAsJsonObject();
+
+        if (allObjects == null) {
+            throw new DownloadException("The assets json file was invalid.");
+        }
+
+        for (Map.Entry<String, JsonElement> field : allObjects.entrySet()) {
+            String friendlyName = field.getKey();
+            JsonObject file = field.getValue().getAsJsonObject();
+            String hash = file.get("hash").getAsString();
+            long size = file.get("size").getAsLong();
+
+            File location = new File(Utils.getAssetsDirectory() + File.separator + "objects" + File.separator + hash.substring(0, 2) + File.separator, hash);
+            String url = MojangConstants.getResourceUrl(hash);
+
+            (new File(location.getParent())).mkdirs();
+
+            File virtualOut = new File(Utils.getAssetsDirectory() + File.separator + "virtual" + File.separator + assets + File.separator + friendlyName);
+
+            queue.AddTask(new EnsureFileTask(location, new FileSizeVerifier(size), null, url, virtualOut.getName()));
+
+            if (isVirtual && !virtualOut.exists()) {
+                (new File(virtualOut.getParent())).mkdirs();
+                queue.AddTask(new CopyFileTask(location, virtualOut));
+            }
+        }
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/tasks/HandleVersionFileTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/HandleVersionFileTask.java
@@ -1,0 +1,94 @@
+package net.technicpack.launchercore.install.tasks;
+
+import net.technicpack.launchercore.exception.DownloadException;
+import net.technicpack.launchercore.install.InstalledPack;
+import net.technicpack.launchercore.minecraft.CompleteVersion;
+import net.technicpack.launchercore.minecraft.Library;
+import net.technicpack.launchercore.util.OperatingSystem;
+import net.technicpack.launchercore.util.Utils;
+import net.technicpack.launchercore.util.verifiers.IFileVerifier;
+import net.technicpack.launchercore.util.verifiers.MD5FileVerifier;
+import net.technicpack.launchercore.util.verifiers.ValidZipFileVerifier;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+public class HandleVersionFileTask implements IInstallTask {
+    private InstalledPack pack;
+    private String libraryName;
+
+    public HandleVersionFileTask(InstalledPack pack) {
+        this.pack = pack;
+    }
+
+    @Override
+    public String getTaskDescription() {
+        if (libraryName == null)
+            return "Processing version.";
+        else
+            return "Verifying " + libraryName + ".";
+    }
+
+    @Override
+    public float getTaskProgress() {
+        return 0;
+    }
+
+    @Override
+    public void runTask(InstallTasksQueue queue) throws IOException {
+        File versionFile = new File(this.pack.getBinDir(), "version.json");
+        String json = FileUtils.readFileToString(versionFile, Charset.forName("UTF-8"));
+        CompleteVersion version = Utils.getMojangGson().fromJson(json, CompleteVersion.class);
+
+        if (version == null) {
+            throw new DownloadException("The version.json file was invalid.");
+        }
+
+        for (Library library : version.getLibrariesForOS()) {
+            // If minecraftforge is described in the libraries, skip it
+            // HACK - Please let us get rid of this when we move to actually hosting forge,
+            // or at least only do it if the users are sticking with modpack.jar
+            if (library.getName().startsWith("net.minecraftforge:minecraftforge") ||
+                    library.getName().startsWith("net.minecraftforge:forge")) {
+                continue;
+            }
+
+            String[] nameBits = library.getName().split(":", 3);
+            libraryName = nameBits[1] + "-" + nameBits[2] + ".jar";
+            queue.RefreshProgress();
+
+            String natives = null;
+            File extractDirectory = null;
+            if (library.getNatives() != null) {
+                natives = library.getNatives().get(OperatingSystem.getOperatingSystem());
+
+                if (natives != null) {
+                    extractDirectory = new File(this.pack.getBinDir(), "natives");
+                }
+            }
+
+            String path = library.getArtifactPath(natives).replace("${arch}", System.getProperty("sun.arch.data.model"));
+            String url = library.getDownloadUrl(path, queue.getMirrorStore()).replace("${arch}", System.getProperty("sun.arch.data.model"));
+            String md5 = queue.getMirrorStore().getETag(url);
+
+            File cache = new File(Utils.getCacheDirectory(), path);
+            if (cache.getParentFile() != null) {
+                cache.getParentFile().mkdirs();
+            }
+
+            IFileVerifier verifier = null;
+            if (md5 != null && !md5.isEmpty()) {
+                verifier = new MD5FileVerifier(md5);
+            } else {
+                verifier = new ValidZipFileVerifier();
+            }
+
+            queue.AddTask(new EnsureFileTask(cache, verifier, extractDirectory, url, library.getExtract()));
+        }
+
+        queue.AddTask(new GetAssetsIndexTask(this.pack));
+        queue.setCompleteVersion(version);
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/tasks/IInstallTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/IInstallTask.java
@@ -24,8 +24,9 @@ import net.technicpack.launchercore.install.InstallTasksQueue;
 import java.io.IOException;
 
 public interface IInstallTask {
-	String getTaskDescription();
-	float getTaskProgress();
+    String getTaskDescription();
 
-	void runTask(InstallTasksQueue queue) throws IOException;
+    float getTaskProgress();
+
+    void runTask(InstallTasksQueue queue) throws IOException;
 }

--- a/src/main/java/net/technicpack/launchercore/install/tasks/InitPackDirectoryTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/InitPackDirectoryTask.java
@@ -1,0 +1,29 @@
+package net.technicpack.launchercore.install.tasks;
+
+import net.technicpack.launchercore.install.InstalledPack;
+
+import java.io.IOException;
+
+public class InitPackDirectoryTask implements IInstallTask {
+    private InstalledPack pack;
+
+    public InitPackDirectoryTask(InstalledPack pack) {
+        this.pack = pack;
+    }
+
+    @Override
+    public String getTaskDescription() {
+        return "Initializing Directories";
+    }
+
+    @Override
+    public float getTaskProgress() {
+        return 0;
+    }
+
+    @Override
+    public void runTask(InstallTasksQueue queue) throws IOException {
+        this.pack.getInstalledDirectory();
+        this.pack.initDirectories();
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/tasks/InstallMinecraftIfNecessaryTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/InstallMinecraftIfNecessaryTask.java
@@ -1,0 +1,51 @@
+package net.technicpack.launchercore.install.tasks;
+
+import net.technicpack.launchercore.install.InstalledPack;
+import net.technicpack.launchercore.minecraft.MojangConstants;
+import net.technicpack.launchercore.util.Utils;
+import net.technicpack.launchercore.util.ZipUtils;
+import net.technicpack.launchercore.util.verifiers.IFileVerifier;
+import net.technicpack.launchercore.util.verifiers.MD5FileVerifier;
+import net.technicpack.launchercore.util.verifiers.ValidZipFileVerifier;
+
+import java.io.File;
+import java.io.IOException;
+
+public class InstallMinecraftIfNecessaryTask extends ListenerTask {
+    private InstalledPack pack;
+    private String minecraftVersion;
+
+    public InstallMinecraftIfNecessaryTask(InstalledPack pack, String minecraftVersion) {
+        this.pack = pack;
+        this.minecraftVersion = minecraftVersion;
+    }
+
+    @Override
+    public String getTaskDescription() {
+        return "Installing Minecraft";
+    }
+
+    @Override
+    public void runTask(InstallTasksQueue queue) throws IOException {
+        super.runTask(queue);
+
+        String url = MojangConstants.getVersionDownload(this.minecraftVersion);
+        String md5 = queue.getMirrorStore().getETag(url);
+        File cache = new File(Utils.getCacheDirectory(), "minecraft_" + this.minecraftVersion + ".jar");
+
+        IFileVerifier verifier = null;
+
+        if (md5 != null && !md5.isEmpty()) {
+            verifier = new MD5FileVerifier(md5);
+        } else {
+            verifier = new ValidZipFileVerifier();
+        }
+
+        if (!cache.exists() || !verifier.isFileValid(cache)) {
+            String output = this.pack.getCacheDir() + File.separator + "minecraft.jar";
+            queue.getMirrorStore().downloadFile(url, cache.getName(), output, cache, verifier, this);
+        }
+
+        ZipUtils.copyMinecraftJar(cache, new File(this.pack.getBinDir(), "minecraft.jar"));
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/tasks/InstallModpackTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/InstallModpackTask.java
@@ -1,0 +1,89 @@
+package net.technicpack.launchercore.install.tasks;
+
+import net.technicpack.launchercore.exception.CacheDeleteException;
+import net.technicpack.launchercore.install.InstalledPack;
+import net.technicpack.launchercore.restful.Modpack;
+import net.technicpack.launchercore.restful.solder.Mod;
+import net.technicpack.launchercore.util.verifiers.IFileVerifier;
+import net.technicpack.launchercore.util.verifiers.MD5FileVerifier;
+import net.technicpack.launchercore.util.verifiers.ValidZipFileVerifier;
+
+import java.io.File;
+import java.io.IOException;
+
+public class InstallModpackTask implements IInstallTask {
+    private InstalledPack pack;
+    private Modpack modpack;
+
+    public InstallModpackTask(InstalledPack pack, Modpack modpack) {
+        this.pack = pack;
+        this.modpack = modpack;
+    }
+
+    @Override
+    public String getTaskDescription() {
+        return "Wiping Folders";
+    }
+
+    @Override
+    public float getTaskProgress() {
+        return 0;
+    }
+
+    @Override
+    public void runTask(InstallTasksQueue queue) throws IOException {
+        File modsDir = this.pack.getModsDir();
+
+        if (modsDir != null && modsDir.exists()) {
+            deleteMods(modsDir);
+        }
+
+        File coremodsDir = this.pack.getCoremodsDir();
+
+        if (coremodsDir != null && coremodsDir.exists()) {
+            deleteMods(coremodsDir);
+        }
+
+        //HACK - jamioflan is a big jerk who needs to put his mods in the dang mod directory!
+        File flansDir = new File(this.pack.getInstalledDirectory(), "Flan");
+
+        if (flansDir.exists()) {
+            deleteMods(flansDir);
+        }
+
+        File packOutput = this.pack.getInstalledDirectory();
+        for (Mod mod : modpack.getMods()) {
+            String url = mod.getUrl();
+            String md5 = mod.getMd5();
+            String name = mod.getName() + "-" + mod.getVersion() + ".zip";
+
+            File cache = new File(this.pack.getCacheDir(), name);
+
+            IFileVerifier verifier = null;
+
+            if (md5 != null && !md5.isEmpty())
+                verifier = new MD5FileVerifier(md5);
+            else
+                verifier = new ValidZipFileVerifier();
+
+            queue.AddNextTask(new EnsureFileTask(cache, verifier, packOutput, url));
+        }
+
+        queue.AddTask(new CleanupModpackCacheTask(this.pack, modpack));
+    }
+
+    private void deleteMods(File modsDir) throws CacheDeleteException {
+        for (File mod : modsDir.listFiles()) {
+            if (mod.isDirectory()) {
+                deleteMods(mod);
+                continue;
+            }
+
+            if (mod.getName().endsWith(".zip") || mod.getName().endsWith(".jar") || mod.getName().endsWith(".litemod")) {
+                if (!mod.delete()) {
+                    throw new CacheDeleteException(mod.getAbsolutePath());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/tasks/InstallTasksQueue.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/InstallTasksQueue.java
@@ -1,0 +1,55 @@
+package net.technicpack.launchercore.install.tasks;
+
+import net.technicpack.launchercore.minecraft.CompleteVersion;
+import net.technicpack.launchercore.mirror.MirrorStore;
+import net.technicpack.launchercore.util.DownloadListener;
+
+import java.io.IOException;
+import java.util.LinkedList;
+
+public class InstallTasksQueue {
+    private DownloadListener listener;
+    private LinkedList<IInstallTask> tasks;
+    private IInstallTask currentTask;
+    private CompleteVersion completeVersion;
+    private MirrorStore mirrorStore;
+
+    public InstallTasksQueue(DownloadListener listener, MirrorStore mirrorStore) {
+        this.listener = listener;
+        this.mirrorStore = mirrorStore;
+        this.tasks = new LinkedList<IInstallTask>();
+        this.currentTask = null;
+    }
+
+    public void RefreshProgress() {
+        listener.stateChanged(currentTask.getTaskDescription(), currentTask.getTaskProgress());
+    }
+
+    public void RunAllTasks() throws IOException {
+        while (!tasks.isEmpty()) {
+            currentTask = tasks.removeFirst();
+            RefreshProgress();
+            currentTask.runTask(this);
+        }
+    }
+
+    public void AddNextTask(IInstallTask task) {
+        tasks.addFirst(task);
+    }
+
+    public void AddTask(IInstallTask task) {
+        tasks.addLast(task);
+    }
+
+    public void setCompleteVersion(CompleteVersion version) {
+        this.completeVersion = version;
+    }
+
+    public CompleteVersion getCompleteVersion() {
+        return this.completeVersion;
+    }
+
+    public MirrorStore getMirrorStore() {
+        return this.mirrorStore;
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/tasks/ListenerTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/ListenerTask.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 
 public abstract class ListenerTask implements IInstallTask, DownloadListener {
 
+<<<<<<< HEAD
 	private float taskProgress;
 	private InstallTasksQueue queue;
 
@@ -51,4 +52,31 @@ public abstract class ListenerTask implements IInstallTask, DownloadListener {
 		this.taskProgress = progress;
 		this.queue.refreshProgress();
 	}
+=======
+    private float taskProgress;
+    private InstallTasksQueue queue;
+
+    public ListenerTask() {
+        taskProgress = 0;
+    }
+
+    @Override
+    public float getTaskProgress() {
+        return this.taskProgress;
+    }
+
+    @Override
+    public void runTask(InstallTasksQueue queue) throws IOException {
+        this.queue = queue;
+    }
+
+    protected void setQueue(InstallTasksQueue queue) {
+        this.queue = queue;
+    }
+
+    public void stateChanged(String fileName, float progress) {
+        this.taskProgress = progress;
+        this.queue.RefreshProgress();
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.
 }

--- a/src/main/java/net/technicpack/launchercore/install/tasks/UnzipFileTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/UnzipFileTask.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.zip.ZipException;
 
 public class UnzipFileTask extends ListenerTask {
+<<<<<<< HEAD
 	private File zipFile;
 	private File destination;
     private IZipFileFilter filter;
@@ -57,4 +58,39 @@ public class UnzipFileTask extends ListenerTask {
 
 		ZipUtils.unzipFile(zipFile, destination, filter, this);
 	}
+=======
+    private File zipFile;
+    private File destination;
+    private ExtractRules rules;
+
+    public UnzipFileTask(File zipFile, File destination) {
+        this(zipFile, destination, null);
+    }
+
+    public UnzipFileTask(File zipFile, File destination, ExtractRules rules) {
+        this.zipFile = zipFile;
+        this.destination = destination;
+        this.rules = rules;
+    }
+
+    @Override
+    public String getTaskDescription() {
+        return "Unzipping " + this.zipFile.getName();
+    }
+
+    @Override
+    public void runTask(InstallTasksQueue queue) throws IOException {
+        super.runTask(queue);
+
+        if (!zipFile.exists()) {
+            throw new ZipException("Attempting to extract file " + zipFile.getName() + ", but it did not exist.");
+        }
+
+        if (!destination.exists()) {
+            destination.mkdirs();
+        }
+
+        ZipUtils.unzipFile(zipFile, destination, this);
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.
 }

--- a/src/main/java/net/technicpack/launchercore/install/tasks/VerifyVersionFilePresentTask.java
+++ b/src/main/java/net/technicpack/launchercore/install/tasks/VerifyVersionFilePresentTask.java
@@ -1,0 +1,53 @@
+package net.technicpack.launchercore.install.tasks;
+
+import net.technicpack.launchercore.exception.PackNotAvailableOfflineException;
+import net.technicpack.launchercore.install.InstalledPack;
+import net.technicpack.launchercore.minecraft.TechnicConstants;
+import net.technicpack.launchercore.util.ZipUtils;
+import net.technicpack.launchercore.util.verifiers.IFileVerifier;
+import net.technicpack.launchercore.util.verifiers.ValidJsonFileVerifier;
+
+import java.io.File;
+import java.io.IOException;
+
+public class VerifyVersionFilePresentTask implements IInstallTask {
+    private InstalledPack pack;
+    private String minecraftVersion;
+
+    public VerifyVersionFilePresentTask(InstalledPack pack, String minecraftVersion) {
+        this.pack = pack;
+        this.minecraftVersion = minecraftVersion;
+    }
+
+    @Override
+    public String getTaskDescription() {
+        return "Retrieving Modpack Version";
+    }
+
+    @Override
+    public float getTaskProgress() {
+        return 0;
+    }
+
+    @Override
+    public void runTask(InstallTasksQueue queue) throws IOException {
+        File versionFile = new File(this.pack.getBinDir(), "version.json");
+        File modpackJar = new File(this.pack.getBinDir(), "modpack.jar");
+
+        boolean didExtract = false;
+
+        if (modpackJar.exists()) {
+            didExtract = ZipUtils.extractFile(modpackJar, this.pack.getBinDir(), "version.json");
+        }
+
+        IFileVerifier fileVerifier = new ValidJsonFileVerifier();
+
+        if (!versionFile.exists() || !fileVerifier.isFileValid(versionFile)) {
+            if (this.pack.isLocalOnly()) {
+                throw new PackNotAvailableOfflineException(this.pack.getDisplayName());
+            } else {
+                queue.AddNextTask(new DownloadFileTask(TechnicConstants.getTechnicVersionJson(this.minecraftVersion), versionFile, fileVerifier));
+            }
+        }
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/user/IAuthListener.java
+++ b/src/main/java/net/technicpack/launchercore/install/user/IAuthListener.java
@@ -1,0 +1,5 @@
+package net.technicpack.launchercore.install.user;
+
+public interface IAuthListener {
+    void userChanged(User user);
+}

--- a/src/main/java/net/technicpack/launchercore/install/user/IUserStore.java
+++ b/src/main/java/net/technicpack/launchercore/install/user/IUserStore.java
@@ -1,0 +1,21 @@
+package net.technicpack.launchercore.install.user;
+
+import java.util.Collection;
+
+public interface IUserStore {
+    void addUser(User user);
+
+    void removeUser(String username);
+
+    User getUser(String username);
+
+    String getClientToken();
+
+    Collection<String> getUsers();
+
+    Collection<User> getSavedUsers();
+
+    void setLastUser(String username);
+
+    String getLastUser();
+}

--- a/src/main/java/net/technicpack/launchercore/install/user/User.java
+++ b/src/main/java/net/technicpack/launchercore/install/user/User.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.install.user;
+
+import com.google.gson.JsonObject;
+import net.technicpack.launchercore.auth.AuthResponse;
+import net.technicpack.launchercore.auth.Profile;
+import net.technicpack.launchercore.util.Utils;
+
+public class User {
+    private String username;
+    private String accessToken;
+    private String clientToken;
+    private String displayName;
+    private Profile profile;
+    private JsonObject userProperties;
+    private transient boolean isOffline;
+
+    public User() {
+        isOffline = false;
+    }
+
+    //This constructor is used to build a user for offline mode
+    public User(String username) {
+        this.username = username;
+        this.displayName = username;
+        this.accessToken = "0";
+        this.clientToken = "0";
+        this.profile = new Profile("0", "");
+        this.isOffline = true;
+        this.userProperties = Utils.getGson().fromJson("{}", JsonObject.class);
+    }
+
+    public User(String username, AuthResponse response) {
+        this.isOffline = false;
+        this.username = username;
+        this.accessToken = response.getAccessToken();
+        this.clientToken = response.getClientToken();
+        this.displayName = response.getSelectedProfile().getName();
+        this.profile = response.getSelectedProfile();
+
+        if (response.getUser() == null) {
+            this.userProperties = Utils.getGson().fromJson("{}", JsonObject.class);
+        } else {
+            this.userProperties = response.getUser().getUserProperties();
+        }
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getClientToken() {
+        return clientToken;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public Profile getProfile() {
+        return profile;
+    }
+
+    public boolean isOffline() {
+        return isOffline;
+    }
+
+    public String getSessionId() {
+        return "token:" + accessToken + ":" + profile.getId();
+    }
+
+    public void rotateAccessToken(String newToken) {
+        this.accessToken = newToken;
+    }
+
+    public String getUserPropertiesAsJson() {
+        return Utils.getGson().toJson(this.userProperties);
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/user/UserModel.java
+++ b/src/main/java/net/technicpack/launchercore/install/user/UserModel.java
@@ -1,0 +1,138 @@
+package net.technicpack.launchercore.install.user;
+
+import net.technicpack.launchercore.auth.AuthResponse;
+import net.technicpack.launchercore.auth.AuthenticationService;
+import net.technicpack.launchercore.exception.AuthenticationNetworkFailureException;
+import net.technicpack.launchercore.exception.DownloadException;
+import net.technicpack.launchercore.mirror.secure.rest.ISecureMirror;
+import net.technicpack.launchercore.mirror.secure.rest.ValidateRequest;
+import net.technicpack.launchercore.mirror.secure.rest.ValidateResponse;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+public class UserModel {
+    private static UserModel mInstance = null;
+
+    private User mCurrentUser = null;
+    private List<IAuthListener> mAuthListeners = new LinkedList<IAuthListener>();
+    private IUserStore mUserStore;
+
+    public UserModel(IUserStore userStore) {
+        this.mCurrentUser = null;
+        this.mUserStore = userStore;
+    }
+
+    public User getCurrentUser() {
+        return this.mCurrentUser;
+    }
+
+    public void setCurrentUser(User user) {
+        this.mCurrentUser = user;
+        this.triggerAuthListeners();
+    }
+
+    public void addAuthListener(IAuthListener listener) {
+        this.mAuthListeners.add(listener);
+    }
+
+    protected void triggerAuthListeners() {
+        for (IAuthListener listener : mAuthListeners) {
+            listener.userChanged(this.mCurrentUser);
+        }
+    }
+
+    public AuthError AttemptLastUserRefresh() throws AuthenticationNetworkFailureException {
+        String lastUser = mUserStore.getLastUser();
+
+        if (lastUser == null || lastUser.isEmpty()) {
+            return new AuthError("No cached user", "Could not log into the last logged in user, as there was no cached user to log into.");
+        }
+
+        User user = mUserStore.getUser(lastUser);
+
+        if (user == null) {
+            return new AuthError("No cached user", "Could not log into the specified user, as there was no cached user to log into.");
+        }
+
+        return AttemptUserRefresh(user);
+    }
+
+    public AuthError AttemptUserRefresh(User user) throws AuthenticationNetworkFailureException {
+        AuthResponse response = AuthenticationService.requestRefresh(user);
+        if (response == null) {
+            mUserStore.removeUser(user.getUsername());
+            return new AuthError("Session Error", "Please log in again.");
+        } else if (response.getError() != null) {
+            mUserStore.removeUser(user.getUsername());
+            return new AuthError(response.getError(), response.getErrorMessage());
+        } else {
+            //Refresh user from response
+            user = new User(user.getUsername(), response);
+            mUserStore.addUser(user);
+            setCurrentUser(user);
+            return null;
+        }
+    }
+
+    public String retrieveDownloadToken(ISecureMirror mirror) throws DownloadException {
+        if (this.getCurrentUser() == null)
+            return null;
+
+        ValidateResponse response = mirror.validate(new ValidateRequest(this.getCurrentUser().getClientToken(), this.getCurrentUser().getAccessToken()));
+
+        if (!response.wasValid())
+            throw new DownloadException(response.getErrorMessage());
+
+        //this.getCurrentUser().rotateAccessToken(response.getAccessToken());
+        //mUserStore.addUser(this.getCurrentUser());
+        return response.getDownloadToken();
+    }
+
+    public Collection<User> getUsers() {
+        return mUserStore.getSavedUsers();
+    }
+
+    public User getLastUser() {
+        return mUserStore.getUser(mUserStore.getLastUser());
+    }
+
+    public User getUser(String username) {
+        return mUserStore.getUser(username);
+    }
+
+    public void addUser(User user) {
+        mUserStore.addUser(user);
+    }
+
+    public void removeUser(User user) {
+        mUserStore.removeUser(user.getUsername());
+    }
+
+    public void setLastUser(User user) {
+        mUserStore.setLastUser(user.getUsername());
+    }
+
+    public String getClientToken() {
+        return mUserStore.getClientToken();
+    }
+
+    public class AuthError {
+        private String mError;
+        private String mErrorDescription;
+
+        public AuthError(String error, String errorDescription) {
+            this.mError = error;
+            this.mErrorDescription = errorDescription;
+        }
+
+        public String getError() {
+            return mError;
+        }
+
+        public String getErrorDescription() {
+            return mErrorDescription;
+        }
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/user/skins/ISkinListener.java
+++ b/src/main/java/net/technicpack/launchercore/install/user/skins/ISkinListener.java
@@ -1,0 +1,9 @@
+package net.technicpack.launchercore.install.user.skins;
+
+import net.technicpack.launchercore.install.user.User;
+
+public interface ISkinListener {
+    void skinReady(User user);
+
+    void faceReady(User user);
+}

--- a/src/main/java/net/technicpack/launchercore/install/user/skins/ISkinMapper.java
+++ b/src/main/java/net/technicpack/launchercore/install/user/skins/ISkinMapper.java
@@ -1,0 +1,15 @@
+package net.technicpack.launchercore.install.user.skins;
+
+import net.technicpack.launchercore.install.user.User;
+
+import java.awt.image.BufferedImage;
+
+public interface ISkinMapper {
+    String getSkinFilename(User user);
+
+    String getFaceFilename(User user);
+
+    BufferedImage getDefaultSkinImage();
+
+    BufferedImage getDefaultFaceImage();
+}

--- a/src/main/java/net/technicpack/launchercore/install/user/skins/ISkinStore.java
+++ b/src/main/java/net/technicpack/launchercore/install/user/skins/ISkinStore.java
@@ -1,0 +1,9 @@
+package net.technicpack.launchercore.install.user.skins;
+
+import net.technicpack.launchercore.install.user.User;
+
+public interface ISkinStore {
+    void downloadUserSkin(User user, String location);
+
+    void downloadUserFace(User user, String location);
+}

--- a/src/main/java/net/technicpack/launchercore/install/user/skins/MinotarSkinStore.java
+++ b/src/main/java/net/technicpack/launchercore/install/user/skins/MinotarSkinStore.java
@@ -1,0 +1,36 @@
+package net.technicpack.launchercore.install.user.skins;
+
+import net.technicpack.launchercore.install.user.User;
+import net.technicpack.launchercore.mirror.MirrorStore;
+import net.technicpack.launchercore.util.Utils;
+
+import java.io.IOException;
+import java.util.logging.Level;
+
+public class MinotarSkinStore implements ISkinStore {
+    private String mBaseUrl;
+    private MirrorStore mirrorStore;
+
+    public MinotarSkinStore(String baseUrl, MirrorStore mirrorStore) {
+        mBaseUrl = baseUrl;
+        this.mirrorStore = mirrorStore;
+    }
+
+    @Override
+    public void downloadUserSkin(User user, String location) {
+        try {
+            mirrorStore.downloadFile(mBaseUrl + "skin/" + user.getDisplayName(), user.getDisplayName(), location);
+        } catch (IOException e) {
+            Utils.getLogger().log(Level.INFO, "Error downloading user face image: " + user.getDisplayName(), e);
+        }
+    }
+
+    @Override
+    public void downloadUserFace(User user, String location) {
+        try {
+            mirrorStore.downloadFile(mBaseUrl + "helm/" + user.getDisplayName() + "/100", user.getDisplayName(), location);
+        } catch (IOException e) {
+            Utils.getLogger().log(Level.INFO, "Error downloading user face image: " + user.getDisplayName(), e);
+        }
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/user/skins/SkinRepository.java
+++ b/src/main/java/net/technicpack/launchercore/install/user/skins/SkinRepository.java
@@ -1,0 +1,133 @@
+package net.technicpack.launchercore.install.user.skins;
+
+import net.technicpack.launchercore.install.user.User;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+public class SkinRepository {
+
+    private ISkinStore mSkinStore;
+    private ISkinMapper mSkinMapper;
+    private List<ISkinListener> mListeners = new LinkedList<ISkinListener>();
+
+    public SkinRepository(ISkinMapper mapper, ISkinStore skinStore) {
+        this.mSkinMapper = mapper;
+        this.mSkinStore = skinStore;
+    }
+
+    public void addListener(ISkinListener listener) {
+        this.mListeners.add(listener);
+    }
+
+    protected void triggerFaceReady(User user) {
+        for (ISkinListener listener : mListeners) {
+            listener.faceReady(user);
+        }
+    }
+
+    protected void triggerSkinReady(User user) {
+        for (ISkinListener listener : mListeners) {
+            listener.skinReady(user);
+        }
+    }
+
+    public BufferedImage getFaceImage(User user) {
+        String expectedFilename = mSkinMapper.getFaceFilename(user);
+        File asset = new File(expectedFilename);
+
+        BufferedImage output = null;
+
+        try {
+            asset.mkdirs();
+            output = ImageIO.read(asset);
+        } catch (IOException ex) {
+            //It almost certainly just doesn't exist and that's OK
+        }
+
+        if (output == null) {
+            final User outputUser = user;
+            Thread faceThread = new Thread("Face Download: " + user.getDisplayName()) {
+                @Override
+                public void run() {
+                    downloadFaceImage(outputUser);
+                    EventQueue.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            triggerFaceReady(outputUser);
+                        }
+                    });
+                }
+            };
+            faceThread.start();
+            return mSkinMapper.getDefaultFaceImage();
+        }
+
+        return output;
+    }
+
+    public BufferedImage getSkinImage(User user) {
+        String expectedFilename = mSkinMapper.getSkinFilename(user);
+        File asset = new File(expectedFilename);
+
+        BufferedImage output = null;
+
+        try {
+            asset.mkdirs();
+            output = ImageIO.read(asset);
+        } catch (IOException ex) {
+            //It almost certainly just doesn't exist and that's OK
+        }
+
+        if (output == null) {
+            final User outputUser = user;
+            Thread skinThread = new Thread("Skin Download: " + user.getDisplayName()) {
+                @Override
+                public void run() {
+                    downloadSkinImage(outputUser);
+                    EventQueue.invokeLater(new Runnable() {
+                        @Override
+                        public void run() {
+                            triggerSkinReady(outputUser);
+                        }
+                    });
+                }
+            };
+            skinThread.start();
+            return mSkinMapper.getDefaultSkinImage();
+        }
+
+        return output;
+    }
+
+    public BufferedImage getDefaultFace() {
+        return mSkinMapper.getDefaultFaceImage();
+    }
+
+    public BufferedImage getDefaultSkin() {
+        return mSkinMapper.getDefaultSkinImage();
+    }
+
+    protected void downloadFaceImage(User user) {
+        String target = this.mSkinMapper.getFaceFilename(user);
+
+        File targetFile = new File(target);
+        targetFile.mkdirs();
+
+        this.mSkinStore.downloadUserFace(user, target);
+    }
+
+    protected void downloadSkinImage(User user) {
+        String target = this.mSkinMapper.getSkinFilename(user);
+
+        File targetFile = new File(target);
+        targetFile.mkdirs();
+
+        this.mSkinStore.downloadUserSkin(user, target);
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/install/verifiers/MD5FileVerifier.java
+++ b/src/main/java/net/technicpack/launchercore/install/verifiers/MD5FileVerifier.java
@@ -19,7 +19,14 @@
 
 package net.technicpack.launchercore.install.verifiers;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/install/verifiers/MD5FileVerifier.java
 import net.technicpack.utilslib.MD5Utils;
+=======
+public class Profile {
+    private String id;
+    private String name;
+    private boolean legacy;
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/auth/Profile.java
 
 import java.io.File;
 
@@ -30,6 +37,7 @@ public class MD5FileVerifier implements IFileVerifier {
         this.md5Hash = md5Hash;
     }
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/install/verifiers/MD5FileVerifier.java
     public boolean isFileValid(File file) {
         if (md5Hash == null || md5Hash.isEmpty())
             return false;
@@ -38,5 +46,25 @@ public class MD5FileVerifier implements IFileVerifier {
 
         System.out.println("Expected MD5: " + md5Hash + " Calculated MD5: " + resultMD5);
         return (md5Hash.equalsIgnoreCase(resultMD5));
+=======
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isLegacy() {
+        return legacy;
+    }
+
+    @Override
+    public String toString() {
+        return "Profile{" +
+                "id='" + id + '\'' +
+                ", name='" + name + '\'' +
+                '}';
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/auth/Profile.java
     }
 }

--- a/src/main/java/net/technicpack/launchercore/launch/GameProcess.java
+++ b/src/main/java/net/technicpack/launchercore/launch/GameProcess.java
@@ -23,6 +23,7 @@ import net.technicpack.utilslib.Utils;
 
 import java.util.List;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/launch/GameProcess.java
 public class GameProcess {
 	private final List<String> commands;
 	private final Process process;
@@ -51,8 +52,30 @@ public class GameProcess {
 	public void setExitListener(ProcessExitListener exitListener) {
 		this.exitListener = exitListener;
 	}
+=======
+public class MinecraftProcess {
+    private final List<String> commands;
+    private final Process process;
+    private MinecraftExitListener exitListener;
+    private final ProcessMonitorThread monitorThread;
 
-	public Process getProcess() {
-		return process;
-	}
+    public MinecraftProcess(List<String> commands, Process process) {
+        this.commands = commands;
+        this.process = process;
+        this.monitorThread = new ProcessMonitorThread(this);
+        this.monitorThread.start();
+    }
+
+    public MinecraftExitListener getExitListener() {
+        return exitListener;
+    }
+
+    public void setExitListener(MinecraftExitListener exitListener) {
+        this.exitListener = exitListener;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/launch/MinecraftProcess.java
+
+    public Process getProcess() {
+        return process;
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/launch/LaunchOptions.java
+++ b/src/main/java/net/technicpack/launchercore/launch/LaunchOptions.java
@@ -22,63 +22,63 @@ package net.technicpack.launchercore.launch;
 import java.util.List;
 
 public class LaunchOptions {
-	private int width;
-	private int height;
-	private boolean fullscreen;
-	private String title;
-	private String iconPath;
+    private int width;
+    private int height;
+    private boolean fullscreen;
+    private String title;
+    private String iconPath;
 
-	public LaunchOptions(String title, String iconPath, int width, int height, boolean fullscreen) {
-		this.width = width;
-		this.height = height;
-		this.fullscreen = fullscreen;
-		this.title = title;
-		this.iconPath = iconPath;
-	}
+    public LaunchOptions(String title, String iconPath, int width, int height, boolean fullscreen) {
+        this.width = width;
+        this.height = height;
+        this.fullscreen = fullscreen;
+        this.title = title;
+        this.iconPath = iconPath;
+    }
 
-	public String getTitle() {
-		return title;
-	}
+    public String getTitle() {
+        return title;
+    }
 
-	public String getIconPath() {
-		return iconPath;
-	}
+    public String getIconPath() {
+        return iconPath;
+    }
 
-	public int getWidth() {
-		return width;
-	}
+    public int getWidth() {
+        return width;
+    }
 
-	public int getHeight() {
-		return height;
-	}
+    public int getHeight() {
+        return height;
+    }
 
-	public boolean getFullscreen() {
-		return fullscreen;
-	}
+    public boolean getFullscreen() {
+        return fullscreen;
+    }
 
-	public void appendToCommands(List<String> commands) {
-		if (getTitle() != null) {
-			commands.add("--title");
-			commands.add(title);
-		}
+    public void appendToCommands(List<String> commands) {
+        if (getTitle() != null) {
+            commands.add("--title");
+            commands.add(title);
+        }
 
-		if (getWidth() > -1) {
-			commands.add("--width");
-			commands.add(Integer.toString(getWidth()));
-		}
+        if (getWidth() > -1) {
+            commands.add("--width");
+            commands.add(Integer.toString(getWidth()));
+        }
 
-		if (getHeight() > -1) {
-			commands.add("--height");
-			commands.add(Integer.toString(getHeight()));
-		}
+        if (getHeight() > -1) {
+            commands.add("--height");
+            commands.add(Integer.toString(getHeight()));
+        }
 
-		if (getFullscreen()) {
-			commands.add("--fullscreen");
-		}
+        if (getFullscreen()) {
+            commands.add("--fullscreen");
+        }
 
-		if (getIconPath() != null) {
-			commands.add("--icon");
-			commands.add(getIconPath());
-		}
-	}
+        if (getIconPath() != null) {
+            commands.add("--icon");
+            commands.add(getIconPath());
+        }
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/launch/MinecraftLauncher.java
+++ b/src/main/java/net/technicpack/launchercore/launch/MinecraftLauncher.java
@@ -1,0 +1,204 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.launch;
+
+import net.technicpack.launchercore.install.InstalledPack;
+import net.technicpack.launchercore.install.user.User;
+import net.technicpack.launchercore.minecraft.CompleteVersion;
+import net.technicpack.launchercore.minecraft.Library;
+import net.technicpack.launchercore.mirror.MirrorStore;
+import net.technicpack.launchercore.restful.PlatformConstants;
+import net.technicpack.launchercore.util.OperatingSystem;
+import net.technicpack.launchercore.util.Utils;
+import org.apache.commons.lang3.text.StrSubstitutor;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+public class MinecraftLauncher {
+    private final int memory;
+    private final InstalledPack pack;
+    private final CompleteVersion version;
+
+    public MinecraftLauncher(int memory, InstalledPack pack, CompleteVersion version) {
+        this.memory = memory;
+        this.pack = pack;
+        this.version = version;
+    }
+
+    public MinecraftProcess launch(User user, LaunchOptions options, MirrorStore mirrorStore) throws IOException {
+        return launch(user, options, null, mirrorStore);
+    }
+
+    public MinecraftProcess launch(User user, LaunchOptions options, MinecraftExitListener exitListener, MirrorStore mirrorStore) throws IOException {
+        List<String> commands = buildCommands(user, options);
+        StringBuilder full = new StringBuilder();
+        boolean first = true;
+
+        for (String part : commands) {
+            if (!first) full.append(" ");
+            full.append(part);
+            first = false;
+        }
+        System.out.println("Running " + full.toString());
+        Utils.pingHttpURL(PlatformConstants.getRunCountUrl(pack.getName()), mirrorStore);
+        if (!Utils.sendTracking("runModpack", pack.getName(), pack.getBuild())) {
+            System.out.println("Failed to record event");
+        }
+        Process process = new ProcessBuilder(commands).directory(pack.getInstalledDirectory()).redirectErrorStream(true).start();
+        MinecraftProcess mcProcess = new MinecraftProcess(commands, process);
+        if (exitListener != null) mcProcess.setExitListener(exitListener);
+        return mcProcess;
+    }
+
+    private List<String> buildCommands(User user, LaunchOptions options) {
+        List<String> commands = new ArrayList<String>();
+        commands.add(OperatingSystem.getJavaDir());
+
+        OperatingSystem operatingSystem = OperatingSystem.getOperatingSystem();
+
+        if (operatingSystem.equals(OperatingSystem.OSX)) {
+            //TODO: -Xdock:icon=<icon path>
+            commands.add("-Xdock:name=" + pack.getDisplayName());
+        } else if (operatingSystem.equals(OperatingSystem.WINDOWS)) {
+            // I have no idea if this helps technic or not.
+            commands.add("-XX:HeapDumpPath=MojangTricksIntelDriversForPerformance_javaw.exe_minecraft.exe.heapdump");
+        }
+        commands.add("-Xmx" + memory + "m");
+        int permSize = 128;
+        if (memory >= 2048) {
+            permSize = 256;
+        }
+        commands.add("-XX:MaxPermSize=" + permSize + "m");
+        commands.add("-Djava.library.path=" + new File(pack.getBinDir(), "natives").getAbsolutePath());
+        // Tell forge 1.5 to download from our mirror instead
+        commands.add("-Dfml.core.libraries.mirror=http://mirror.technicpack.net/Technic/lib/fml/%s");
+        commands.add("-Dminecraft.applet.TargetDirectory=" + pack.getInstalledDirectory().getAbsolutePath());
+
+        String javaArguments = version.getJavaArguments();
+
+        if (javaArguments != null && !javaArguments.isEmpty()) {
+            commands.addAll(Arrays.asList(javaArguments.split(" ")));
+        }
+
+        commands.add("-cp");
+        commands.add(buildClassPath());
+        commands.add(version.getMainClass());
+        commands.addAll(Arrays.asList(getMinecraftArguments(version, pack.getInstalledDirectory(), user)));
+        options.appendToCommands(commands);
+
+        //TODO: Add all the other less important commands
+        return commands;
+    }
+
+    private String[] getMinecraftArguments(CompleteVersion version, File gameDirectory, User user) {
+        Map<String, String> map = new HashMap<String, String>();
+        StrSubstitutor substitutor = new StrSubstitutor(map);
+        String[] split = version.getMinecraftArguments().split(" ");
+
+        map.put("auth_username", user.getUsername());
+        map.put("auth_session", user.getSessionId());
+        map.put("auth_access_token", user.getAccessToken());
+
+        map.put("auth_player_name", user.getDisplayName());
+        map.put("auth_uuid", user.getProfile().getId());
+
+        map.put("profile_name", user.getDisplayName());
+        map.put("version_name", version.getId());
+
+        map.put("game_directory", gameDirectory.getAbsolutePath());
+
+        String targetAssets = Utils.getAssetsDirectory().getAbsolutePath();
+
+        String assetsKey = this.version.getAssetsKey();
+
+        if (assetsKey == null || assetsKey.isEmpty()) {
+            assetsKey = "legacy";
+        }
+
+        if (this.version.getAreAssetsVirtual()) {
+            targetAssets += File.separator + "virtual" + File.separator + assetsKey;
+        }
+
+        map.put("game_assets", targetAssets);
+        map.put("assets_root", targetAssets);
+        map.put("assets_index_name", assetsKey);
+        map.put("user_type", user.getProfile().isLegacy() ? "legacy" : "mojang");
+        map.put("user_properties", user.getUserPropertiesAsJson());
+
+        for (int i = 0; i < split.length; i++) {
+            split[i] = substitutor.replace(split[i]);
+        }
+
+        return split;
+    }
+
+    private String buildClassPath() {
+        StringBuilder result = new StringBuilder();
+        String separator = System.getProperty("path.separator");
+
+        // Add all the libraries to the classpath.
+        for (Library library : version.getLibrariesForOS()) {
+            if (library.getNatives() != null) {
+                continue;
+            }
+
+            // If minecraftforge is described in the libraries, skip it
+            // HACK - Please let us get rid of this when we move to actually hosting forge,
+            // or at least only do it if the users are sticking with modpack.jar
+            if (library.getName().startsWith("net.minecraftforge:minecraftforge") ||
+                    library.getName().startsWith("net.minecraftforge:forge")) {
+                continue;
+            }
+
+            File file = new File(Utils.getCacheDirectory(), library.getArtifactPath().replace("${arch}", System.getProperty("sun.arch.data.model")));
+            if (!file.isFile() || !file.exists()) {
+                throw new RuntimeException("Library " + library.getName() + " not found.");
+            }
+
+            if (result.length() > 1) {
+                result.append(separator);
+            }
+            result.append(file.getAbsolutePath());
+        }
+
+        // Add the modpack.jar to the classpath, if it exists and minecraftforge is not a library already
+        File modpack = new File(pack.getBinDir(), "modpack.jar");
+        if (modpack.exists()) {
+            if (result.length() > 1) {
+                result.append(separator);
+            }
+            result.append(modpack.getAbsolutePath());
+        }
+
+        // Add the minecraft jar to the classpath
+        File minecraft = new File(pack.getBinDir(), "minecraft.jar");
+        if (!minecraft.exists()) {
+            throw new RuntimeException("Minecraft not installed for this pack: " + pack);
+        }
+        if (result.length() > 1) {
+            result.append(separator);
+        }
+        result.append(minecraft.getAbsolutePath());
+
+        return result.toString();
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/launch/ProcessExitListener.java
+++ b/src/main/java/net/technicpack/launchercore/launch/ProcessExitListener.java
@@ -21,5 +21,9 @@ package net.technicpack.launchercore.launch;
 
 public interface ProcessExitListener {
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/launch/ProcessExitListener.java
 	public void onProcessExit();
+=======
+    public void onMinecraftExit();
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/launch/MinecraftExitListener.java
 }

--- a/src/main/java/net/technicpack/launchercore/launch/ProcessMonitorThread.java
+++ b/src/main/java/net/technicpack/launchercore/launch/ProcessMonitorThread.java
@@ -25,32 +25,40 @@ import java.io.InputStreamReader;
 
 public class ProcessMonitorThread extends Thread {
 
+<<<<<<< HEAD
 	private final GameProcess process;
 
 	public ProcessMonitorThread(GameProcess process) {
 		super("ProcessMonitorThread");
 		this.process = process;
 	}
+=======
+    private final MinecraftProcess process;
 
-	public void run() {
-		InputStreamReader reader = new InputStreamReader(this.process.getProcess().getInputStream());
-		BufferedReader buf = new BufferedReader(reader);
-		String line = null;
+    public ProcessMonitorThread(MinecraftProcess process) {
+        super("ProcessMonitorThread");
+        this.process = process;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.
 
-		while (true) {
-			try {
-				while ((line = buf.readLine()) != null) {
-					System.out.println(" " + line);
-				}
-			} catch (IOException ex) {
+    public void run() {
+        InputStreamReader reader = new InputStreamReader(this.process.getProcess().getInputStream());
+        BufferedReader buf = new BufferedReader(reader);
+        String line = null;
+
+        while (true) {
+            try {
+                while ((line = buf.readLine()) != null) {
+                    System.out.println(" " + line);
+                }
+            } catch (IOException ex) {
 //				Logger.getLogger(ProcessMonitorThread.class.getName()).log(Level.SEVERE, null, ex);
-			} finally {
-				try {
-					buf.close();
-				} catch (IOException ex) {
+            } finally {
+                try {
+                    buf.close();
+                } catch (IOException ex) {
 //					Logger.getLogger(ProcessMonitorThread.class.getName()).log(Level.SEVERE, null, ex);
-				} finally
-                {
+                } finally {
                     try {
                         process.getProcess().waitFor();
                     } catch (InterruptedException e) {
@@ -58,11 +66,18 @@ public class ProcessMonitorThread extends Thread {
                     }
                     break;
                 }
-			}
-		}
+            }
+        }
 
+<<<<<<< HEAD
 		if (process.getExitListener() != null) {
 			process.getExitListener().onProcessExit();
 		}
 	}
+=======
+        if (process.getExitListener() != null) {
+            process.getExitListener().onMinecraftExit();
+        }
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.
 }

--- a/src/main/java/net/technicpack/launchercore/minecraft/CompleteVersion.java
+++ b/src/main/java/net/technicpack/launchercore/minecraft/CompleteVersion.java
@@ -1,0 +1,142 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.minecraft;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class CompleteVersion implements Version {
+
+    private String id;
+    private Date time;
+    private Date releaseTime;
+    private ReleaseType type;
+    private String minecraftArguments;
+    private String javaArguments;
+    private List<Library> libraries;
+    private String mainClass;
+    private int minimumLauncherVersion;
+    private String incompatibilityReason;
+    private List<Rule> rules;
+    private String assets;
+    private transient boolean areAssetsVirtual;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public ReleaseType getType() {
+        return type;
+    }
+
+    @Override
+    public void setType(ReleaseType type) {
+        this.type = type;
+    }
+
+    @Override
+    public Date getUpdatedTime() {
+        return time;
+    }
+
+    @Override
+    public void setUpdatedTime(Date updatedTime) {
+        this.time = updatedTime;
+    }
+
+    @Override
+    public Date getReleaseTime() {
+        return releaseTime;
+    }
+
+    @Override
+    public void setReleaseTime(Date releaseTime) {
+        this.releaseTime = releaseTime;
+    }
+
+    public String getMinecraftArguments() {
+        return minecraftArguments;
+    }
+
+    public String getJavaArguments() {
+        return javaArguments;
+    }
+
+    public List<Library> getLibraries() {
+        return libraries;
+    }
+
+    public List<Library> getLibrariesForOS() {
+        List<Library> libraryList = new ArrayList<Library>(libraries.size());
+        for (Library library : libraries) {
+            if (library.isForCurrentOS()) {
+                libraryList.add(library);
+            }
+        }
+        return libraryList;
+    }
+
+    public String getMainClass() {
+        return mainClass;
+    }
+
+    public int getMinimumLauncherVersion() {
+        return minimumLauncherVersion;
+    }
+
+    public String getIncompatibilityReason() {
+        return incompatibilityReason;
+    }
+
+    public List<Rule> getRules() {
+        return rules;
+    }
+
+    public String getAssetsKey() {
+        return assets;
+    }
+
+    public boolean getAreAssetsVirtual() {
+        return areAssetsVirtual;
+    }
+
+    public void setAreAssetsVirtual(boolean areAssetsVirtual) {
+        this.areAssetsVirtual = areAssetsVirtual;
+    }
+
+    @Override
+    public String toString() {
+        return "CompleteVersion{" +
+                "id='" + id + '\'' +
+                ", time=" + time +
+                ", releaseTime=" + releaseTime +
+                ", type=" + type +
+                ", minecraftArguments='" + minecraftArguments + '\'' +
+                ", libraries=" + libraries +
+                ", mainClass='" + mainClass + '\'' +
+                ", minimumLauncherVersion=" + minimumLauncherVersion +
+                ", incompatibilityReason='" + incompatibilityReason + '\'' +
+                ", rules=" + rules +
+                '}';
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/minecraft/ExtractRules.java
+++ b/src/main/java/net/technicpack/launchercore/minecraft/ExtractRules.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.minecraft;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ExtractRules {
+    private List<String> exclude = new ArrayList<String>();
+
+    public ExtractRules() {
+
+    }
+
+    public ExtractRules(String[] exclude) {
+        if (exclude != null) {
+            Collections.addAll(this.exclude, exclude);
+        }
+    }
+
+    public List<String> getExclude() {
+        return exclude;
+    }
+
+    public boolean shouldExtract(String path) {
+        if (this.exclude != null) {
+            for (String rule : this.exclude) {
+                if (path.startsWith(rule)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/minecraft/Library.java
+++ b/src/main/java/net/technicpack/launchercore/minecraft/Library.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.minecraft;
+
+import net.technicpack.launchercore.mirror.MirrorStore;
+import net.technicpack.launchercore.util.OperatingSystem;
+import net.technicpack.launchercore.util.Utils;
+import org.apache.commons.lang3.text.StrSubstitutor;
+
+import java.util.List;
+import java.util.Map;
+
+public class Library {
+    private static final StrSubstitutor SUBSTITUTOR = new StrSubstitutor();
+    private static final String[] fallback = {"http://mirror.technicpack.net/Technic/lib/", "http://search.maven.org/remotecontent?filepath="};
+    private String name;
+    private List<Rule> rules;
+    private Map<OperatingSystem, String> natives;
+    private ExtractRules extract;
+    private String url;
+
+    public String getName() {
+        return name;
+    }
+
+    public List<Rule> getRules() {
+        return rules;
+    }
+
+    public Map<OperatingSystem, String> getNatives() {
+        return natives;
+    }
+
+    public ExtractRules getExtract() {
+        return extract;
+    }
+
+    public boolean isForCurrentOS() {
+        if (rules == null) {
+            return true;
+        }
+
+        Rule.Action lastAction = Rule.Action.DISALLOW;
+
+        for (Rule rule : rules) {
+            Rule.Action action = rule.getAction();
+            if (action != null) {
+                lastAction = action;
+            }
+        }
+
+        return lastAction.equals(Rule.Action.ALLOW);
+    }
+
+    public String getArtifactPath() {
+        return getArtifactPath(null);
+    }
+
+    public String getArtifactPath(String classifier) {
+        if (this.name == null) {
+            throw new IllegalStateException("Cannot get artifact path of empty/blank artifact");
+        }
+        return String.format("%s/%s", getArtifactBaseDir(), getArtifactFilename(classifier));
+    }
+
+    public String getArtifactBaseDir() {
+        if (this.name == null) {
+            throw new IllegalStateException("Cannot get artifact dir of empty/blank artifact");
+        }
+        String[] parts = this.name.split(":", 3);
+        return String.format("%s/%s/%s", parts[0].replaceAll("\\.", "/"), parts[1], parts[2]);
+    }
+
+    public String getArtifactFilename(String classifier) {
+        if (this.name == null) {
+            throw new IllegalStateException("Cannot get artifact filename of empty/blank artifact");
+        }
+
+        String[] parts = this.name.split(":", 3);
+        String result;
+
+        if (classifier != null) {
+            result = String.format("%s-%s%s.jar", parts[1], parts[2], "-" + classifier);
+        } else {
+            result = String.format("%s-%s%s.jar", parts[1], parts[2], "");
+        }
+
+        return SUBSTITUTOR.replace(result);
+    }
+
+    public String getDownloadUrl(String path, MirrorStore mirrorStore) {
+        if (this.url != null) {
+            String checkUrl = url + path;
+            if (Utils.pingHttpURL(checkUrl, mirrorStore)) {
+                return checkUrl;
+            }
+            for (String string : fallback) {
+                checkUrl = string + path;
+                if (Utils.pingHttpURL(checkUrl, mirrorStore)) {
+                    return checkUrl;
+                }
+            }
+        }
+        return " https://libraries.minecraft.net/" + path;
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/minecraft/MojangConstants.java
+++ b/src/main/java/net/technicpack/launchercore/minecraft/MojangConstants.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.minecraft;
+
+public class MojangConstants {
+    public static final String baseURL = "https://s3.amazonaws.com/Minecraft.Download/";
+    public static final String assetsIndexes = baseURL + "indexes/";
+    public static final String versions = baseURL + "versions/";
+    public static final String assets = "http://resources.download.minecraft.net/";
+    public static final String versionList = versions + "versions.json";
+
+    public static String getVersionJson(String version) {
+        return versions + version + "/" + version + ".json";
+    }
+
+    public static String getVersionDownload(String version) {
+        return versions + version + "/" + version + ".jar";
+    }
+
+    public static String getAssetsIndex(String assetsKey) {
+        return assetsIndexes + assetsKey + ".json";
+    }
+
+    public static String getResourceUrl(String hash) {
+        return assets + hash.substring(0, 2) + "/" + hash;
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/minecraft/Rule.java
+++ b/src/main/java/net/technicpack/launchercore/minecraft/Rule.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.minecraft;
+
+import net.technicpack.launchercore.util.OperatingSystem;
+
+public class Rule {
+    private Action action = Action.ALLOW;
+    private OSRestriction os;
+
+    public Action getAction() {
+        if (this.os != null && !this.os.matchesCurrentOperatingSystem()) {
+            return null;
+        }
+
+        return action;
+    }
+
+    public static enum Action {
+        ALLOW,
+        DISALLOW
+    }
+
+    public class OSRestriction {
+        private OperatingSystem name;
+        private String version;
+
+        public boolean matchesCurrentOperatingSystem() {
+            if (this.name != null && (this.name != OperatingSystem.getOperatingSystem())) {
+                return false;
+            }
+
+            boolean matched = true;
+
+            if (this.version != null) {
+                String osVersion = System.getProperty("os.version");
+                matched = osVersion.matches(this.version);
+            }
+
+            return matched;
+        }
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/mirror/MirrorStore.java
+++ b/src/main/java/net/technicpack/launchercore/mirror/MirrorStore.java
@@ -1,17 +1,17 @@
 /**
  * This file is part of Technic Launcher Core.
  * Copyright (C) 2013 Syndicate, LLC
- *
+ * <p/>
  * Technic Launcher Core is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p/>
  * Technic Launcher Core is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p/>
  * You should have received a copy of the GNU General Public License,
  * as well as a copy of the GNU Lesser General Public License,
  * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
@@ -38,8 +38,7 @@ public class MirrorStore {
     Map<String, SecureToken> secureMirrors = new HashMap<String, SecureToken>();
     private UserModel userModel;
 
-    public MirrorStore(UserModel userModel)
-    {
+    public MirrorStore(UserModel userModel) {
         this.userModel = userModel;
     }
 
@@ -55,7 +54,7 @@ public class MirrorStore {
         try {
             urlObject = new URL(url);
         } catch (MalformedURLException ex) {
-            throw new DownloadException("Invalid URL: "+url, ex);
+            throw new DownloadException("Invalid URL: " + url, ex);
         }
 
         String host = urlObject.getHost().toLowerCase();
@@ -165,12 +164,12 @@ public class MirrorStore {
             textUrl += "&";
         }
 
-        textUrl += "t="+downloadKey+"&c="+clientId;
+        textUrl += "t=" + downloadKey + "&c=" + clientId;
 
         try {
             return new URL(textUrl);
         } catch (MalformedURLException ex) {
-            throw new Error("Code error: managed to take valid url "+url.toString() + " and turn it into invalid URL "+textUrl);
+            throw new Error("Code error: managed to take valid url " + url.toString() + " and turn it into invalid URL " + textUrl);
         }
     }
 }

--- a/src/main/java/net/technicpack/launchercore/mirror/download/Download.java
+++ b/src/main/java/net/technicpack/launchercore/mirror/download/Download.java
@@ -19,6 +19,12 @@
 
 package net.technicpack.launchercore.mirror.download;
 
+import net.technicpack.launchercore.exception.DownloadException;
+import net.technicpack.launchercore.exception.PermissionDeniedException;
+import net.technicpack.launchercore.util.DownloadListener;
+import net.technicpack.launchercore.util.Utils;
+import org.apache.commons.io.IOUtils;
+
 import java.io.*;
 import java.net.*;
 import java.nio.channels.Channels;
@@ -26,6 +32,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+<<<<<<< HEAD
 import net.technicpack.launchercore.exception.DownloadException;
 import net.technicpack.launchercore.exception.PermissionDeniedException;
 
@@ -33,210 +40,212 @@ import net.technicpack.launchercore.util.DownloadListener;
 import net.technicpack.utilslib.Utils;
 import org.apache.commons.io.IOUtils;
 
+=======
+>>>>>>> Re-tab & optimize imports for all files in core.
 public class Download implements Runnable {
-	private static final long TIMEOUT = 30000;
+    private static final long TIMEOUT = 30000;
 
-	private URL url;
-	private long size = -1;
-	private long downloaded = 0;
-	private String outPath;
-	private String name;
-	private DownloadListener listener;
-	private Result result = Result.FAILURE;
-	private File outFile = null;
-	private Exception exception = null;
+    private URL url;
+    private long size = -1;
+    private long downloaded = 0;
+    private String outPath;
+    private String name;
+    private DownloadListener listener;
+    private Result result = Result.FAILURE;
+    private File outFile = null;
+    private Exception exception = null;
 
-	public Download(URL url, String name, String outPath) throws MalformedURLException {
-		this.url = url;
-		this.outPath = outPath;
-		this.name = name;
-	}
+    public Download(URL url, String name, String outPath) throws MalformedURLException {
+        this.url = url;
+        this.outPath = outPath;
+        this.name = name;
+    }
 
-	public float getProgress() {
-		return ((float) downloaded / size) * 100;
-	}
+    public float getProgress() {
+        return ((float) downloaded / size) * 100;
+    }
 
-	public Exception getException() {
-		return exception;
-	}
+    public Exception getException() {
+        return exception;
+    }
 
-	@Override
-	@SuppressWarnings("unused")
-	public void run() {
-		ReadableByteChannel rbc = null;
-		FileOutputStream fos = null;
-		try {
-			HttpURLConnection conn = Utils.openHttpConnection(url);
-			int response = conn.getResponseCode();
-			int responseFamily = response/100;
+    @Override
+    @SuppressWarnings("unused")
+    public void run() {
+        ReadableByteChannel rbc = null;
+        FileOutputStream fos = null;
+        try {
+            HttpURLConnection conn = Utils.openHttpConnection(url);
+            int response = conn.getResponseCode();
+            int responseFamily = response / 100;
 
-			if (responseFamily == 3) {
-				throw new DownloadException("The server issued a redirect response which Technic failed to follow.");
-			} else if (responseFamily != 2) {
-				throw new DownloadException("The server issued a "+response+" response code.");
-			}
+            if (responseFamily == 3) {
+                throw new DownloadException("The server issued a redirect response which Technic failed to follow.");
+            } else if (responseFamily != 2) {
+                throw new DownloadException("The server issued a " + response + " response code.");
+            }
 
-			InputStream in = getConnectionInputStream(conn);
+            InputStream in = getConnectionInputStream(conn);
 
-			size = conn.getContentLength();
-			outFile = new File(outPath);
-			outFile.delete();
+            size = conn.getContentLength();
+            outFile = new File(outPath);
+            outFile.delete();
 
-			rbc = Channels.newChannel(in);
-			fos = new FileOutputStream(outFile);
+            rbc = Channels.newChannel(in);
+            fos = new FileOutputStream(outFile);
 
-			stateChanged();
+            stateChanged();
 
-			Thread progress = new MonitorThread(Thread.currentThread(), rbc);
-			progress.start();
+            Thread progress = new MonitorThread(Thread.currentThread(), rbc);
+            progress.start();
 
-			fos.getChannel().transferFrom(rbc, 0, size > 0 ? size : Integer.MAX_VALUE);
-			in.close();
-			rbc.close();
-			progress.interrupt();
-			if (size > 0) {
-				if (size == outFile.length()) {
-					result = Result.SUCCESS;
-				}
-			} else {
-				result = Result.SUCCESS;
-			}
-		} catch (PermissionDeniedException e) {
-			exception = e;
-			result = Result.PERMISSION_DENIED;
-		} catch (DownloadException e) {
-			exception = e;
-			result = Result.FAILURE;
-		} catch (Exception e) {
-			exception = e;
-			e.printStackTrace();
-		} finally {
-			IOUtils.closeQuietly(fos);
-			IOUtils.closeQuietly(rbc);
-		}
-	}
+            fos.getChannel().transferFrom(rbc, 0, size > 0 ? size : Integer.MAX_VALUE);
+            in.close();
+            rbc.close();
+            progress.interrupt();
+            if (size > 0) {
+                if (size == outFile.length()) {
+                    result = Result.SUCCESS;
+                }
+            } else {
+                result = Result.SUCCESS;
+            }
+        } catch (PermissionDeniedException e) {
+            exception = e;
+            result = Result.PERMISSION_DENIED;
+        } catch (DownloadException e) {
+            exception = e;
+            result = Result.FAILURE;
+        } catch (Exception e) {
+            exception = e;
+            e.printStackTrace();
+        } finally {
+            IOUtils.closeQuietly(fos);
+            IOUtils.closeQuietly(rbc);
+        }
+    }
 
-	protected InputStream getConnectionInputStream(final URLConnection urlconnection) throws DownloadException {
-		final AtomicReference<InputStream> is = new AtomicReference<InputStream>();
+    protected InputStream getConnectionInputStream(final URLConnection urlconnection) throws DownloadException {
+        final AtomicReference<InputStream> is = new AtomicReference<InputStream>();
 
-		for (int j = 0; (j < 3) && (is.get() == null); j++) {
-			StreamThread stream = new StreamThread(urlconnection, is);
-			stream.start();
-			int iterationCount = 0;
-			while ((is.get() == null) && (iterationCount++ < 5)) {
-				try {
-					stream.join(1000L);
-				} catch (InterruptedException ignore) {
-				}
-			}
+        for (int j = 0; (j < 3) && (is.get() == null); j++) {
+            StreamThread stream = new StreamThread(urlconnection, is);
+            stream.start();
+            int iterationCount = 0;
+            while ((is.get() == null) && (iterationCount++ < 5)) {
+                try {
+                    stream.join(1000L);
+                } catch (InterruptedException ignore) {
+                }
+            }
 
-			if (stream.permDenied.get()) {
-				throw new PermissionDeniedException("Permission denied!");
-			}
+            if (stream.permDenied.get()) {
+                throw new PermissionDeniedException("Permission denied!");
+            }
 
-			if (is.get() != null) {
-				break;
-			}
-			try {
-				stream.interrupt();
-				stream.join();
-			} catch (InterruptedException ignore) {
-			}
-		}
+            if (is.get() != null) {
+                break;
+            }
+            try {
+                stream.interrupt();
+                stream.join();
+            } catch (InterruptedException ignore) {
+            }
+        }
 
-		if (is.get() == null) {
-			throw new DownloadException("Unable to download file from " + urlconnection.getURL());
-		}
-		return new BufferedInputStream(is.get());
-	}
+        if (is.get() == null) {
+            throw new DownloadException("Unable to download file from " + urlconnection.getURL());
+        }
+        return new BufferedInputStream(is.get());
+    }
 
-	private void stateChanged() {
-		if (listener != null)
-			listener.stateChanged(name, getProgress());
-	}
+    private void stateChanged() {
+        if (listener != null)
+            listener.stateChanged(name, getProgress());
+    }
 
-	public void setListener(DownloadListener listener) {
-		this.listener = listener;
-	}
+    public void setListener(DownloadListener listener) {
+        this.listener = listener;
+    }
 
-	public Result getResult() {
-		return result;
-	}
+    public Result getResult() {
+        return result;
+    }
 
-	public File getOutFile() {
-		return outFile;
-	}
+    public File getOutFile() {
+        return outFile;
+    }
 
-	private static class StreamThread extends Thread {
-		private final URLConnection urlconnection;
-		private final AtomicReference<InputStream> is;
-		public final AtomicBoolean permDenied = new AtomicBoolean(false);
+    private static class StreamThread extends Thread {
+        private final URLConnection urlconnection;
+        private final AtomicReference<InputStream> is;
+        public final AtomicBoolean permDenied = new AtomicBoolean(false);
 
-		public StreamThread(URLConnection urlconnection, AtomicReference<InputStream> is) {
-			this.urlconnection = urlconnection;
-			this.is = is;
-		}
+        public StreamThread(URLConnection urlconnection, AtomicReference<InputStream> is) {
+            this.urlconnection = urlconnection;
+            this.is = is;
+        }
 
-		@Override
-		public void run() {
-			try {
-				is.set(urlconnection.getInputStream());
-			} catch (SocketException e) {
-				if (e.getMessage().equalsIgnoreCase("Permission denied: connect")) {
-					permDenied.set(true);
-				}
-			} catch (IOException ignore) {
-			}
-		}
-	}
+        @Override
+        public void run() {
+            try {
+                is.set(urlconnection.getInputStream());
+            } catch (SocketException e) {
+                if (e.getMessage().equalsIgnoreCase("Permission denied: connect")) {
+                    permDenied.set(true);
+                }
+            } catch (IOException ignore) {
+            }
+        }
+    }
 
-	private class MonitorThread extends Thread {
-		private final ReadableByteChannel rbc;
-		private final Thread downloadThread;
-		private long last = System.currentTimeMillis();
+    private class MonitorThread extends Thread {
+        private final ReadableByteChannel rbc;
+        private final Thread downloadThread;
+        private long last = System.currentTimeMillis();
 
-		public MonitorThread(Thread downloadThread, ReadableByteChannel rbc) {
-			super("Download Monitor Thread");
-			this.setDaemon(true);
-			this.rbc = rbc;
-			this.downloadThread = downloadThread;
-		}
+        public MonitorThread(Thread downloadThread, ReadableByteChannel rbc) {
+            super("Download Monitor Thread");
+            this.setDaemon(true);
+            this.rbc = rbc;
+            this.downloadThread = downloadThread;
+        }
 
-		@Override
-		public void run() {
-			while (!this.isInterrupted()) {
-				long diff = outFile.length() - downloaded;
-				downloaded = outFile.length();
-				if (diff == 0) {
-					if ((System.currentTimeMillis() - last) > TIMEOUT) {
-						if (listener != null) {
-							listener.stateChanged("Download Failed", getProgress());
-						}
-						try {
-							rbc.close();
-							downloadThread.interrupt();
-						} catch (Exception ignore) {
-							//We catch all exceptions here, because ReadableByteChannel is AWESOME
-							//and was throwing NPE's sometimes when we tried to close it after
-							//the connection broke.
-						}
-						return;
-					}
-				} else {
-					last = System.currentTimeMillis();
-				}
+        @Override
+        public void run() {
+            while (!this.isInterrupted()) {
+                long diff = outFile.length() - downloaded;
+                downloaded = outFile.length();
+                if (diff == 0) {
+                    if ((System.currentTimeMillis() - last) > TIMEOUT) {
+                        if (listener != null) {
+                            listener.stateChanged("Download Failed", getProgress());
+                        }
+                        try {
+                            rbc.close();
+                            downloadThread.interrupt();
+                        } catch (Exception ignore) {
+                            //We catch all exceptions here, because ReadableByteChannel is AWESOME
+                            //and was throwing NPE's sometimes when we tried to close it after
+                            //the connection broke.
+                        }
+                        return;
+                    }
+                } else {
+                    last = System.currentTimeMillis();
+                }
 
-				stateChanged();
-				try {
-					sleep(50);
-				} catch (InterruptedException ignore) {
-					return;
-				}
-			}
-		}
-	}
+                stateChanged();
+                try {
+                    sleep(50);
+                } catch (InterruptedException ignore) {
+                    return;
+                }
+            }
+        }
+    }
 
-	public enum Result {
-		SUCCESS, FAILURE, PERMISSION_DENIED,
-	}
+    public enum Result {
+        SUCCESS, FAILURE, PERMISSION_DENIED,
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/mirror/secure/SecureToken.java
+++ b/src/main/java/net/technicpack/launchercore/mirror/secure/SecureToken.java
@@ -1,17 +1,17 @@
 /**
  * This file is part of Technic Launcher Core.
  * Copyright (C) 2013 Syndicate, LLC
- *
+ * <p/>
  * Technic Launcher Core is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p/>
  * Technic Launcher Core is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p/>
  * You should have received a copy of the GNU General Public License,
  * as well as a copy of the GNU Lesser General Public License,
  * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.

--- a/src/main/java/net/technicpack/launchercore/mirror/secure/rest/ISecureMirror.java
+++ b/src/main/java/net/technicpack/launchercore/mirror/secure/rest/ISecureMirror.java
@@ -1,17 +1,17 @@
 /**
  * This file is part of Technic Launcher Core.
  * Copyright (C) 2013 Syndicate, LLC
- *
+ * <p/>
  * Technic Launcher Core is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p/>
  * Technic Launcher Core is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p/>
  * You should have received a copy of the GNU General Public License,
  * as well as a copy of the GNU Lesser General Public License,
  * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
@@ -21,5 +21,6 @@ package net.technicpack.launchercore.mirror.secure.rest;
 
 public interface ISecureMirror {
     String getDownloadHost();
+
     ValidateResponse validate(ValidateRequest req);
 }

--- a/src/main/java/net/technicpack/launchercore/mirror/secure/rest/JsonWebSecureMirror.java
+++ b/src/main/java/net/technicpack/launchercore/mirror/secure/rest/JsonWebSecureMirror.java
@@ -1,17 +1,17 @@
 /**
  * This file is part of Technic Launcher Core.
  * Copyright (C) 2013 Syndicate, LLC
- *
+ * <p/>
  * Technic Launcher Core is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p/>
  * Technic Launcher Core is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p/>
  * You should have received a copy of the GNU General Public License,
  * as well as a copy of the GNU Lesser General Public License,
  * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
@@ -38,7 +38,7 @@ public class JsonWebSecureMirror implements ISecureMirror {
 
     @Override
     public ValidateResponse validate(ValidateRequest req) {
-        String constructedUrl = baseUrl + "validate?a=" + req.getAccessToken() + "&c="+req.getClientToken();
+        String constructedUrl = baseUrl + "validate?a=" + req.getAccessToken() + "&c=" + req.getClientToken();
 
         try {
             return RestObject.getRestObject(ValidateResponse.class, constructedUrl);

--- a/src/main/java/net/technicpack/launchercore/mirror/secure/rest/ValidateRequest.java
+++ b/src/main/java/net/technicpack/launchercore/mirror/secure/rest/ValidateRequest.java
@@ -1,17 +1,17 @@
 /**
  * This file is part of Technic Launcher Core.
  * Copyright (C) 2013 Syndicate, LLC
- *
+ * <p/>
  * Technic Launcher Core is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p/>
  * Technic Launcher Core is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p/>
  * You should have received a copy of the GNU General Public License,
  * as well as a copy of the GNU Lesser General Public License,
  * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
@@ -30,6 +30,11 @@ public class ValidateRequest extends RestObject {
         this.accessToken = accessToken;
     }
 
-    public String getAccessToken() { return accessToken; }
-    public String getClientToken() { return clientToken; }
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getClientToken() {
+        return clientToken;
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/mirror/secure/rest/ValidateResponse.java
+++ b/src/main/java/net/technicpack/launchercore/mirror/secure/rest/ValidateResponse.java
@@ -1,17 +1,17 @@
 /**
  * This file is part of Technic Launcher Core.
  * Copyright (C) 2013 Syndicate, LLC
- *
+ * <p/>
  * Technic Launcher Core is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p/>
  * Technic Launcher Core is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p/>
  * You should have received a copy of the GNU General Public License,
  * as well as a copy of the GNU Lesser General Public License,
  * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
@@ -28,15 +28,31 @@ public class ValidateResponse extends RestObject {
     private String accessToken;
     private String downloadToken;
 
-    public ValidateResponse() {}
+    public ValidateResponse() {
+    }
+
     public ValidateResponse(String errorMessage) {
         this.valid = false;
         this.message = errorMessage;
     }
 
-    public boolean wasValid() { return valid; }
-    public String getErrorMessage() { return message; }
-    public String getClientToken() { return clientToken; }
-    public String getAccessToken() { return accessToken; }
-    public String getDownloadToken() { return downloadToken; }
+    public boolean wasValid() {
+        return valid;
+    }
+
+    public String getErrorMessage() {
+        return message;
+    }
+
+    public String getClientToken() {
+        return clientToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getDownloadToken() {
+        return downloadToken;
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/modpacks/resources/resourcetype/IconResourceType.java
+++ b/src/main/java/net/technicpack/launchercore/modpacks/resources/resourcetype/IconResourceType.java
@@ -19,6 +19,7 @@
 
 package net.technicpack.launchercore.modpacks.resources.resourcetype;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/modpacks/resources/resourcetype/IconResourceType.java
 import net.technicpack.launchercore.modpacks.ModpackModel;
 import net.technicpack.rest.io.Resource;
 
@@ -31,5 +32,22 @@ public class IconResourceType implements IModpackResourceType {
     @Override
     public String getImageName() {
         return "icon.png";
+=======
+public class AuthRequest {
+    private Agent agent;
+    private String username;
+    private String password;
+    private String clientToken;
+
+    public AuthRequest() {
+
+    }
+
+    public AuthRequest(Agent agent, String username, String password, String clientToken) {
+        this.agent = agent;
+        this.username = username;
+        this.password = password;
+        this.clientToken = clientToken;
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/auth/AuthRequest.java
     }
 }

--- a/src/main/java/net/technicpack/launchercore/modpacks/sources/IInstalledPackRepository.java
+++ b/src/main/java/net/technicpack/launchercore/modpacks/sources/IInstalledPackRepository.java
@@ -21,6 +21,7 @@ package net.technicpack.launchercore.modpacks.sources;
 
 import net.technicpack.launchercore.modpacks.InstalledPack;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/launchercore/modpacks/sources/IInstalledPackRepository.java
 import java.util.List;
 import java.util.Map;
 
@@ -32,4 +33,16 @@ public interface IInstalledPackRepository {
 	InstalledPack put(InstalledPack installedPack);
 	InstalledPack remove(String name);
 	void save();
+=======
+    private List<VersionEntry> versions;
+    private LatestEntry latest;
+
+    public List<VersionEntry> getVersions() {
+        return versions;
+    }
+
+    public LatestEntry getLatest() {
+        return latest;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/minecraft/versionlist/VersionList.java
 }

--- a/src/main/java/net/technicpack/launchercore/restful/PlatformConstants.java
+++ b/src/main/java/net/technicpack/launchercore/restful/PlatformConstants.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.restful;
+
+public class PlatformConstants {
+    public static final String PLATFORM = "http://www.technicpack.net/";
+
+    public static final String API = PLATFORM + "api/";
+
+    public static final String MODPACK = API + "modpack/";
+
+    public static final String NEWS = API + "news/";
+
+    public static String getPlatformInfoUrl(String modpack) {
+        return MODPACK + modpack;
+    }
+
+    public static String getRunCountUrl(String modpack) {
+        return getPlatformInfoUrl(modpack) + "/run";
+    }
+
+    public static String getDownloadCountUrl(String modpack) {
+        return getPlatformInfoUrl(modpack) + "/download";
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/restful/platform/Article.java
+++ b/src/main/java/net/technicpack/launchercore/restful/platform/Article.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.restful.platform;
+
+import net.technicpack.launchercore.restful.PlatformConstants;
+import net.technicpack.launchercore.restful.Resource;
+
+public class Article {
+    private String title;
+    private String displayTitle;
+    private Resource image;
+    private String category;
+    private String user;
+    private String summary;
+    private String date;
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDisplayTitle() {
+        return displayTitle;
+    }
+
+    public Resource getImage() {
+        return image;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public String getUrl() {
+        return PlatformConstants.PLATFORM + "article/view/" + title;
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/restful/solder/SolderConstants.java
+++ b/src/main/java/net/technicpack/launchercore/restful/solder/SolderConstants.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Technic Launcher Core.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher Core is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher Core is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License,
+ * as well as a copy of the GNU Lesser General Public License,
+ * along with Technic Launcher Core.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.restful.solder;
+
+import net.technicpack.launchercore.util.Settings;
+
+public class SolderConstants {
+    public static final String TECHNIC = "http://solder.technicpack.net/api/";
+
+    public static String getSolderPackInfoUrl(String solder, String modpack, String profileName) {
+        return solder + "modpack/" + modpack + "/?cid=" + Settings.getClientId() + "&u=" + profileName;
+    }
+
+    public static String getSolderPackInfoUrlWithoutCid(String solder, String modpack) {
+        return solder + "modpack/" + modpack + "/";
+    }
+
+    public static String getSolderBuildUrl(String solder, String modpack, String build, String profileName) {
+        return getSolderPackInfoUrlWithoutCid(solder, modpack) + build + "/?cid=" + Settings.getClientId() + "&u=" + profileName;
+    }
+
+    public static String getFullSolderUrl(String solder, String profileName) {
+        return solder + "modpack/?include=full&cid=" + Settings.getClientId() + "&u=" + profileName;
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/util/DownloadListener.java
+++ b/src/main/java/net/technicpack/launchercore/util/DownloadListener.java
@@ -20,5 +20,5 @@
 package net.technicpack.launchercore.util;
 
 public interface DownloadListener {
-	public void stateChanged(String fileName, float progress);
+    public void stateChanged(String fileName, float progress);
 }

--- a/src/main/java/net/technicpack/launchercore/util/LaunchAction.java
+++ b/src/main/java/net/technicpack/launchercore/util/LaunchAction.java
@@ -19,17 +19,17 @@
 package net.technicpack.launchercore.util;
 
 public enum LaunchAction {
-	HIDE("Hide Launcher"),
-	CLOSE("Close Launcher"),
-	NOTHING("Stay Open");
-	private final String display;
+    HIDE("Hide Launcher"),
+    CLOSE("Close Launcher"),
+    NOTHING("Stay Open");
+    private final String display;
 
-	private LaunchAction(String s) {
-		this.display = s;
-	}
+    private LaunchAction(String s) {
+        this.display = s;
+    }
 
-	@Override
-	public String toString() {
-		return display;
-	}
+    @Override
+    public String toString() {
+        return display;
+    }
 }

--- a/src/main/java/net/technicpack/launchercore/util/ResourceUtils.java
+++ b/src/main/java/net/technicpack/launchercore/util/ResourceUtils.java
@@ -1,0 +1,82 @@
+/*
+ * This file is part of Technic Launcher.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Technic Launcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.util;
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import java.awt.image.BufferedImage;
+import java.io.*;
+
+public class ResourceUtils {
+
+    public static File getResourceAsFile(String path) {
+        File file = new File(".\\src\\main\\resources\\" + path);
+        if (file.exists())
+            return file;
+        else
+            return null;
+    }
+
+    public static ImageIcon getIcon(String iconName) {
+        return new ImageIcon(ResourceUtils.class.getResource("/org/spoutcraft/launcher/resources/" + iconName));
+    }
+
+    public static BufferedImage getImage(String imageName) {
+        try {
+            return ImageIO.read(getResourceAsStream("/org/spoutcraft/launcher/resources/" + imageName));
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public static InputStream getResourceAsStream(String path) {
+        InputStream stream = ResourceUtils.class.getResourceAsStream(path);
+        String[] split = path.split("/");
+        path = split[split.length - 1];
+        if (stream == null) {
+            File resource = new File(".\\src\\main\\resources\\" + path);
+            if (resource.exists()) {
+                try {
+                    stream = new BufferedInputStream(new FileInputStream(resource));
+                } catch (IOException ignore) {
+                }
+            }
+        }
+        return stream;
+    }
+
+    public static BufferedImage getImage(String imageName, int w, int h) {
+        try {
+            return ImageUtils.scaleImage(ImageIO.read(getResourceAsStream("/org/spoutcraft/launcher/resources/" + imageName)), w, h);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public static ImageIcon getIcon(String iconName, int w, int h) {
+        try {
+            return new ImageIcon(ImageUtils.scaleImage(ImageIO.read(getResourceAsStream("/org/spoutcraft/launcher/resources/" + iconName)), w, h));
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/util/Settings.java
+++ b/src/main/java/net/technicpack/launchercore/util/Settings.java
@@ -1,0 +1,162 @@
+/*
+ * This file is part of Technic Launcher.
+ * Copyright (C) 2013 Syndicate, LLC
+ *
+ * Technic Launcher is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Technic Launcher is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Technic Launcher.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.technicpack.launchercore.util;
+
+import com.google.gson.JsonSyntaxException;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.UUID;
+import java.util.logging.Level;
+
+public class Settings {
+    public static final String STABLE = "stable";
+    public static final String BETA = "beta";
+    public static Settings instance = new Settings();
+    private String directory;
+    private int memory;
+    private LaunchAction launchAction;
+    private String buildStream = STABLE;
+    private boolean showConsole;
+    private String languageCode = "default";
+    private boolean migrate;
+    private String clientId = UUID.randomUUID().toString();
+    private String migrateDir;
+
+    public static void load() {
+        File settings = new File(Utils.getSettingsDirectory(), "settings.json");
+        if (!settings.exists()) {
+            Utils.getLogger().log(Level.WARNING, "Unable to load settings from " + settings + " because it does not exist.");
+            return;
+        }
+
+        try {
+            String json = FileUtils.readFileToString(settings, Charset.forName("UTF-8"));
+            instance = Utils.getGson().fromJson(json, Settings.class);
+        } catch (JsonSyntaxException e) {
+            Utils.getLogger().log(Level.WARNING, "Unable to load settings from " + settings);
+        } catch (IOException e) {
+            Utils.getLogger().log(Level.WARNING, "Unable to load settings from " + settings);
+        }
+    }
+
+    public static String getDirectory() {
+        return instance.directory;
+    }
+
+    public static void setDirectory(String directory) {
+        instance.directory = directory;
+        save();
+    }
+
+    public static void save() {
+        File settings = new File(Utils.getSettingsDirectory(), "settings.json");
+
+        String json = Utils.getGson().toJson(instance);
+
+        try {
+            FileUtils.writeStringToFile(settings, json, Charset.forName("UTF-8"));
+        } catch (IOException e) {
+            Utils.getLogger().log(Level.WARNING, "Unable to save settings " + settings, e);
+        }
+    }
+
+    public static int getMemory() {
+        return instance.memory;
+    }
+
+    public static void setMemory(int memory) {
+        instance.memory = memory;
+        save();
+    }
+
+    public static LaunchAction getLaunchAction() {
+        return instance.launchAction;
+    }
+
+    public static void setLaunchAction(LaunchAction launchAction) {
+        instance.launchAction = launchAction;
+        save();
+    }
+
+    public static String getBuildStream() {
+        return instance.buildStream;
+    }
+
+    public static void setBuildStream(String buildStream) {
+        instance.buildStream = buildStream;
+        save();
+    }
+
+    public static String getClientId() {
+        return instance.clientId;
+    }
+
+    public static boolean getShowConsole() {
+        return instance.showConsole;
+    }
+
+    public static void setShowConsole(boolean showConsole) {
+        instance.showConsole = showConsole;
+        save();
+    }
+
+    public static String getLanguageCode() {
+        return instance.languageCode;
+    }
+
+    public static void setLanguageCode(String languageCode) {
+        instance.languageCode = languageCode;
+        save();
+    }
+
+    public static boolean getMigrate() {
+        return instance.migrate;
+    }
+
+    public static void setMigrate(boolean migrate) {
+        instance.migrate = migrate;
+        save();
+    }
+
+    public static String getMigrateDir() {
+        return instance.migrateDir;
+    }
+
+    public static void setMigrateDir(String migrateDir) {
+        instance.migrateDir = migrateDir;
+        save();
+    }
+
+    @Override
+    public String toString() {
+        return "Settings{" +
+                "directory='" + directory + '\'' +
+                ", memory=" + memory +
+                ", buildStream='" + buildStream + '\'' +
+                ", showConsole=" + showConsole +
+                ", migrate=" + migrate +
+                ", migrateDir='" + migrateDir + '\'' +
+                ", launchAction='" + launchAction + '\'' +
+                ", languageCode='" + languageCode + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/net/technicpack/launchercore/util/verifiers/ValidJsonFileVerifier.java
+++ b/src/main/java/net/technicpack/launchercore/util/verifiers/ValidJsonFileVerifier.java
@@ -1,0 +1,25 @@
+package net.technicpack.launchercore.util.verifiers;
+
+import com.google.gson.JsonObject;
+import net.technicpack.launchercore.util.Utils;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.nio.charset.Charset;
+
+public class ValidJsonFileVerifier implements IFileVerifier {
+    @Override
+    public boolean isFileValid(File file) {
+        try {
+            String json = FileUtils.readFileToString(file, Charset.forName("UTF-8"));
+            JsonObject obj = Utils.getMojangGson().fromJson(json, JsonObject.class);
+
+            return (obj != null);
+        } catch (Exception ex) {
+            System.out.println("An exception was raised while verifying " + file.getAbsolutePath() + "- this probably just means the file is invalid, in which case this is not an error:");
+            ex.printStackTrace();
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/net/technicpack/platform/io/AuthorshipInfo.java
+++ b/src/main/java/net/technicpack/platform/io/AuthorshipInfo.java
@@ -21,6 +21,7 @@ package net.technicpack.platform.io;
 
 import java.util.Date;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/platform/io/AuthorshipInfo.java
 public class AuthorshipInfo {
     private String user;
     private String avatar;
@@ -36,4 +37,27 @@ public class AuthorshipInfo {
     public String getUser() { return user; }
     public String getAvatar() { return avatar; }
     public Date getDate() { return date; }
+=======
+public class VersionEntry {
+    private String id;
+    private Date time;
+    private Date releaseTime;
+    private ReleaseType type;
+
+    public String getId() {
+        return id;
+    }
+
+    public Date getTime() {
+        return time;
+    }
+
+    public Date getReleaseTime() {
+        return releaseTime;
+    }
+
+    public ReleaseType getType() {
+        return type;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/minecraft/versionlist/VersionEntry.java
 }

--- a/src/main/java/net/technicpack/platform/io/PlatformPackInfo.java
+++ b/src/main/java/net/technicpack/platform/io/PlatformPackInfo.java
@@ -20,15 +20,22 @@
 package net.technicpack.platform.io;
 
 import net.technicpack.launchercore.exception.BuildInaccessibleException;
+<<<<<<< HEAD:src/main/java/net/technicpack/platform/io/PlatformPackInfo.java
 import net.technicpack.rest.io.Modpack;
 import net.technicpack.rest.io.PackInfo;
 import net.technicpack.rest.io.Resource;
 import net.technicpack.rest.RestObject;
+=======
+import net.technicpack.launchercore.exception.RestfulAPIException;
+import net.technicpack.launchercore.install.user.User;
+import net.technicpack.launchercore.restful.*;
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/restful/platform/PlatformPackInfo.java
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class PlatformPackInfo extends RestObject implements PackInfo {
+<<<<<<< HEAD:src/main/java/net/technicpack/platform/io/PlatformPackInfo.java
 	private String name;
 	private String displayName;
 	private String url;
@@ -164,4 +171,115 @@ public class PlatformPackInfo extends RestObject implements PackInfo {
 				", forceDir=" + forceDir +
 				'}';
 	}
+=======
+    private String name;
+    private String displayName;
+    private String url;
+    private Resource icon;
+    private Resource logo;
+    private Resource background;
+    private String minecraft;
+    private String forge;
+    private String version;
+    private String solder;
+    private boolean forceDir;
+
+    public PlatformPackInfo() {
+
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public Resource getIcon() {
+        return icon;
+    }
+
+    @Override
+    public Resource getBackground() {
+        return background;
+    }
+
+    @Override
+    public Resource getLogo() {
+        return logo;
+    }
+
+    @Override
+    public String getRecommended() {
+        return version;
+    }
+
+    @Override
+    public String getLatest() {
+        return version;
+    }
+
+    @Override
+    public boolean shouldForceDirectory() {
+        return forceDir;
+    }
+
+    @Override
+    public List<String> getBuilds() {
+        List<String> builds = new ArrayList<String>();
+        builds.add(version);
+        return builds;
+    }
+
+    public String getMinecraft() {
+        return minecraft;
+    }
+
+    public String getForge() {
+        return forge;
+    }
+
+    public String getSolder() {
+        return solder;
+    }
+
+    public boolean hasSolder() {
+        return solder != null && !solder.equals("");
+    }
+
+    @Override
+    public Modpack getModpack(String build, User user) throws BuildInaccessibleException {
+        return new Modpack(this);
+    }
+
+    @Override
+    public String toString() {
+        return "PlatformPackInfo{" +
+                "name='" + name + '\'' +
+                ", displayName='" + displayName + '\'' +
+                ", url='" + url + '\'' +
+                ", icon=" + icon +
+                ", logo=" + logo +
+                ", background=" + background +
+                ", minecraft='" + minecraft + '\'' +
+                ", forge='" + forge + '\'' +
+                ", version='" + version + '\'' +
+                ", solder='" + solder + '\'' +
+                ", forceDir=" + forceDir +
+                '}';
+    }
+
+    public static PlatformPackInfo getPlatformPackInfo(String name) throws RestfulAPIException {
+        return getRestObject(PlatformPackInfo.class, PlatformConstants.getPlatformInfoUrl(name));
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/restful/platform/PlatformPackInfo.java
 }

--- a/src/main/java/net/technicpack/platform/io/SearchResultsData.java
+++ b/src/main/java/net/technicpack/platform/io/SearchResultsData.java
@@ -23,8 +23,17 @@ import net.technicpack.rest.RestObject;
 
 import java.util.ArrayList;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/platform/io/SearchResultsData.java
 public class SearchResultsData extends RestObject {
     private SearchResult[] modpacks;
 
     public SearchResult[] getResults() { return modpacks; }
+=======
+public class News extends RestObject {
+    private List<Article> news;
+
+    public List<Article> getNews() {
+        return news;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/restful/platform/News.java
 }

--- a/src/main/java/net/technicpack/rest/RestObject.java
+++ b/src/main/java/net/technicpack/rest/RestObject.java
@@ -28,22 +28,22 @@ import java.io.InputStream;
 import java.net.*;
 
 public class RestObject {
-	private static final Gson gson = new Gson();
+    private static final Gson gson = new Gson();
 
-	private String error;
+    private String error;
 
-	public boolean hasError() {
-		return error != null;
-	}
+    public boolean hasError() {
+        return error != null;
+    }
 
-	public String getError() {
-		return error;
-	}
+    public String getError() {
+        return error;
+    }
 
     public static <T extends RestObject> T postRestObject(Class<T> restObject, String url) throws RestfulAPIException {
         InputStream stream = null;
         try {
-            HttpURLConnection conn = (HttpURLConnection)new URL(url).openConnection();
+            HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
             conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.2.2) Gecko/20100316 Firefox/3.6.2");
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type",
@@ -55,7 +55,7 @@ public class RestObject {
             String data = IOUtils.toString(stream);
             T result = gson.fromJson(data, restObject);
 
-            if (result == null ) {
+            if (result == null) {
                 throw new RestfulAPIException("Unable to access URL [" + url + "]");
             }
 
@@ -66,10 +66,10 @@ public class RestObject {
             return result;
         } catch (SocketTimeoutException e) {
             throw new RestfulAPIException("Timed out accessing URL [" + url + "]", e);
-        }  catch (MalformedURLException e) {
+        } catch (MalformedURLException e) {
             throw new RestfulAPIException("Invalid URL [" + url + "]", e);
         } catch (JsonParseException e) {
-            throw new RestfulAPIException("Error parsing response JSON at URL ["+url+"]",e);
+            throw new RestfulAPIException("Error parsing response JSON at URL [" + url + "]", e);
         } catch (IOException e) {
             throw new RestfulAPIException("Error accessing URL [" + url + "]", e);
         } finally {
@@ -77,37 +77,37 @@ public class RestObject {
         }
     }
 
-	public static <T extends RestObject> T getRestObject(Class<T> restObject, String url) throws RestfulAPIException {
-		InputStream stream = null;
-		try {
-			URLConnection conn = new URL(url).openConnection();
-			conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.2.2) Gecko/20100316 Firefox/3.6.2");
-			conn.setConnectTimeout(15000);
-			conn.setReadTimeout(15000);
+    public static <T extends RestObject> T getRestObject(Class<T> restObject, String url) throws RestfulAPIException {
+        InputStream stream = null;
+        try {
+            URLConnection conn = new URL(url).openConnection();
+            conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.2.2) Gecko/20100316 Firefox/3.6.2");
+            conn.setConnectTimeout(15000);
+            conn.setReadTimeout(15000);
 
-			stream = conn.getInputStream();
-			String data = IOUtils.toString(stream);
-			T result = gson.fromJson(data, restObject);
+            stream = conn.getInputStream();
+            String data = IOUtils.toString(stream);
+            T result = gson.fromJson(data, restObject);
 
-			if (result == null ) {
-				throw new RestfulAPIException("Unable to access URL [" + url + "]");
-			}
+            if (result == null) {
+                throw new RestfulAPIException("Unable to access URL [" + url + "]");
+            }
 
-			if (result.hasError()) {
-				throw new RestfulAPIException("Error in response: " + result.getError());
-			}
+            if (result.hasError()) {
+                throw new RestfulAPIException("Error in response: " + result.getError());
+            }
 
-			return result;
-		} catch (SocketTimeoutException e) {
-			throw new RestfulAPIException("Timed out accessing URL [" + url + "]", e);
-		}  catch (MalformedURLException e) {
-			throw new RestfulAPIException("Invalid URL [" + url + "]", e);
-		} catch (JsonParseException e) {
-			throw new RestfulAPIException("Error parsing response JSON at URL ["+url+"]",e);
-		} catch (IOException e) {
-			throw new RestfulAPIException("Error accessing URL [" + url + "]", e);
-		} finally {
-			IOUtils.closeQuietly(stream);
-		}
-	}
+            return result;
+        } catch (SocketTimeoutException e) {
+            throw new RestfulAPIException("Timed out accessing URL [" + url + "]", e);
+        } catch (MalformedURLException e) {
+            throw new RestfulAPIException("Invalid URL [" + url + "]", e);
+        } catch (JsonParseException e) {
+            throw new RestfulAPIException("Error parsing response JSON at URL [" + url + "]", e);
+        } catch (IOException e) {
+            throw new RestfulAPIException("Error accessing URL [" + url + "]", e);
+        } finally {
+            IOUtils.closeQuietly(stream);
+        }
+    }
 }

--- a/src/main/java/net/technicpack/rest/RestfulAPIException.java
+++ b/src/main/java/net/technicpack/rest/RestfulAPIException.java
@@ -22,35 +22,35 @@ package net.technicpack.rest;
 import java.io.IOException;
 
 public class RestfulAPIException extends IOException {
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	private final Throwable cause;
-	private final String message;
+    private final Throwable cause;
+    private final String message;
 
-	public RestfulAPIException(String message, Throwable cause) {
-		this.cause = cause;
-		this.message = message;
-	}
+    public RestfulAPIException(String message, Throwable cause) {
+        this.cause = cause;
+        this.message = message;
+    }
 
-	public RestfulAPIException(Throwable cause) {
-		this(null, cause);
-	}
+    public RestfulAPIException(Throwable cause) {
+        this(null, cause);
+    }
 
-	public RestfulAPIException(String message) {
-		this(message, null);
-	}
+    public RestfulAPIException(String message) {
+        this(message, null);
+    }
 
-	public RestfulAPIException() {
-		this(null, null);
-	}
+    public RestfulAPIException() {
+        this(null, null);
+    }
 
-	@Override
-	public synchronized Throwable getCause() {
-		return this.cause;
-	}
+    @Override
+    public synchronized Throwable getCause() {
+        return this.cause;
+    }
 
-	@Override
-	public String getMessage() {
-		return message;
-	}
+    @Override
+    public String getMessage() {
+        return message;
+    }
 }

--- a/src/main/java/net/technicpack/rest/io/Mod.java
+++ b/src/main/java/net/technicpack/rest/io/Mod.java
@@ -20,34 +20,34 @@
 package net.technicpack.rest.io;
 
 public class Mod extends Resource {
-	private String name;
-	private String version;
+    private String name;
+    private String version;
 
-	public Mod() {
+    public Mod() {
 
-	}
+    }
 
-	public Mod(String name, String version, String url, String md5) {
-		super(url, md5);
-		this.name = name;
-		this.version = version;
-	}
+    public Mod(String name, String version, String url, String md5) {
+        super(url, md5);
+        this.name = name;
+        this.version = version;
+    }
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public String getVersion() {
-		return version;
-	}
+    public String getVersion() {
+        return version;
+    }
 
-	@Override
-	public String toString() {
-		return "Mod{" +
-				"name='" + name + '\'' +
-				", version='" + version + '\'' +
-				", url='" + getUrl() + '\'' +
-				", md5='" + getMd5() + '\'' +
-				'}';
-	}
+    @Override
+    public String toString() {
+        return "Mod{" +
+                "name='" + name + '\'' +
+                ", version='" + version + '\'' +
+                ", url='" + getUrl() + '\'' +
+                ", md5='" + getMd5() + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/net/technicpack/rest/io/Modpack.java
+++ b/src/main/java/net/technicpack/rest/io/Modpack.java
@@ -26,13 +26,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Modpack extends RestObject {
-	private String minecraft;
-	private List<Mod> mods;
+    private String minecraft;
+    private List<Mod> mods;
 
-	public Modpack() {
+    public Modpack() {
 
-	}
+    }
 
+<<<<<<< HEAD:src/main/java/net/technicpack/rest/io/Modpack.java
 	public Modpack(PlatformPackInfo info) {
         minecraft = info.getGameVersion();
 		mods = new ArrayList<Mod>();
@@ -43,8 +44,20 @@ public class Modpack extends RestObject {
 	public String getGameVersion() {
 		return minecraft;
 	}
+=======
+    public Modpack(PlatformPackInfo info) {
+        minecraft = info.getMinecraft();
+        mods = new ArrayList<Mod>();
+        Mod mod = new Mod(info.getName(), info.getRecommended(), info.getUrl(), "");
+        mods.add(mod);
+    }
 
-	public List<Mod> getMods() {
-		return mods;
-	}
+    public String getMinecraft() {
+        return minecraft;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/restful/Modpack.java
+
+    public List<Mod> getMods() {
+        return mods;
+    }
 }

--- a/src/main/java/net/technicpack/rest/io/PackInfo.java
+++ b/src/main/java/net/technicpack/rest/io/PackInfo.java
@@ -28,26 +28,27 @@ import java.util.List;
 
 public interface PackInfo {
 
-	public String getName();
+    public String getName();
 
-	public String getDisplayName();
+    public String getDisplayName();
 
-	public String getUrl();
+    public String getUrl();
 
-	public Resource getIcon();
+    public Resource getIcon();
 
-	public Resource getBackground();
+    public Resource getBackground();
 
-	public Resource getLogo();
+    public Resource getLogo();
 
-	public String getRecommended();
+    public String getRecommended();
 
-	public String getLatest();
+    public String getLatest();
 
-	public List<String> getBuilds();
+    public List<String> getBuilds();
 
-	public boolean shouldForceDirectory();
+    public boolean shouldForceDirectory();
 
+<<<<<<< HEAD:src/main/java/net/technicpack/rest/io/PackInfo.java
     public ArrayList<FeedItem> getFeed();
 
     public String getDescription();
@@ -61,4 +62,7 @@ public interface PackInfo {
 	public Modpack getModpack(String build) throws BuildInaccessibleException;
 
     public boolean isComplete();
+=======
+    public Modpack getModpack(String build, User user) throws BuildInaccessibleException;
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/restful/PackInfo.java
 }

--- a/src/main/java/net/technicpack/rest/io/Resource.java
+++ b/src/main/java/net/technicpack/rest/io/Resource.java
@@ -21,23 +21,23 @@ package net.technicpack.rest.io;
 
 public class Resource {
 
-	private String url;
-	private String md5;
+    private String url;
+    private String md5;
 
-	public Resource() {
+    public Resource() {
 
-	}
+    }
 
-	public Resource(String url, String md5) {
-		this.url = url;
-		this.md5 = md5;
-	}
+    public Resource(String url, String md5) {
+        this.url = url;
+        this.md5 = md5;
+    }
 
-	public String getUrl() {
-		return url;
-	}
+    public String getUrl() {
+        return url;
+    }
 
-	public String getMd5() {
-		return md5;
-	}
+    public String getMd5() {
+        return md5;
+    }
 }

--- a/src/main/java/net/technicpack/solder/io/FullModpacks.java
+++ b/src/main/java/net/technicpack/solder/io/FullModpacks.java
@@ -25,14 +25,14 @@ import java.util.LinkedHashMap;
 
 public class FullModpacks extends RestObject {
 
-	private LinkedHashMap<String, SolderPackInfo> modpacks;
-	private String mirror_url;
+    private LinkedHashMap<String, SolderPackInfo> modpacks;
+    private String mirror_url;
 
-	public LinkedHashMap<String, SolderPackInfo> getModpacks() {
-		return modpacks;
-	}
+    public LinkedHashMap<String, SolderPackInfo> getModpacks() {
+        return modpacks;
+    }
 
-	public String getMirrorUrl() {
-		return mirror_url;
-	}
+    public String getMirrorUrl() {
+        return mirror_url;
+    }
 }

--- a/src/main/java/net/technicpack/solder/io/Solder.java
+++ b/src/main/java/net/technicpack/solder/io/Solder.java
@@ -24,36 +24,36 @@ import net.technicpack.rest.RestObject;
 import java.util.Map;
 
 public class Solder extends RestObject {
-	private transient String url;
-	private Map<String, String> modpacks;
-	private String mirror_url;
+    private transient String url;
+    private Map<String, String> modpacks;
+    private String mirror_url;
 
-	public Solder() {
+    public Solder() {
 
-	}
+    }
 
-	public Solder(String url) {
-		this.url = url;
-	}
+    public Solder(String url) {
+        this.url = url;
+    }
 
-	public Solder(String url, String mirrorUrl) {
-		this.url = url;
-		this.mirror_url = mirrorUrl;
-	}
+    public Solder(String url, String mirrorUrl) {
+        this.url = url;
+        this.mirror_url = mirrorUrl;
+    }
 
-	public void setUrl(String url) {
-		this.url = url;
-	}
+    public void setUrl(String url) {
+        this.url = url;
+    }
 
-	public String getUrl() {
-		return url;
-	}
+    public String getUrl() {
+        return url;
+    }
 
-	public Map<String, String> getModpacks() {
-		return modpacks;
-	}
+    public Map<String, String> getModpacks() {
+        return modpacks;
+    }
 
-	public String getMirrorUrl() {
-		return mirror_url;
-	}
+    public String getMirrorUrl() {
+        return mirror_url;
+    }
 }

--- a/src/main/java/net/technicpack/solder/io/SolderPackInfo.java
+++ b/src/main/java/net/technicpack/solder/io/SolderPackInfo.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 public class SolderPackInfo extends RestObject implements PackInfo {
 
+<<<<<<< HEAD:src/main/java/net/technicpack/solder/io/SolderPackInfo.java
 	private String name;
 	private String display_name;
 	private String url;
@@ -158,4 +159,144 @@ public class SolderPackInfo extends RestObject implements PackInfo {
 				", solder=" + solder +
 				'}';
 	}
+=======
+    private String name;
+    private String display_name;
+    private String url;
+    private String icon;
+    private String icon_md5;
+    private String logo;
+    private String logo_md5;
+    private String background;
+    private String background_md5;
+    private String recommended;
+    private String latest;
+    private List<String> builds;
+    private transient Solder solder;
+
+    public SolderPackInfo() {
+
+    }
+
+    public Solder getSolder() {
+        return solder;
+    }
+
+    public void setSolder(Solder solder) {
+        this.solder = solder;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return display_name;
+    }
+
+    @Override
+    public String getUrl() {
+        return url;
+    }
+
+    @Override
+    public Resource getIcon() {
+        if (icon == null) {
+            return new Resource(solder.getMirrorUrl() + name + "/resources/icon.png", logo_md5);
+        }
+        return new Resource(icon, icon_md5);
+    }
+
+    @Override
+    public Resource getBackground() {
+        if (background == null) {
+            return new Resource(solder.getMirrorUrl() + name + "/resources/background.jpg", logo_md5);
+        }
+        return new Resource(background, background_md5);
+    }
+
+    @Override
+    public Resource getLogo() {
+        if (logo == null) {
+            return new Resource(solder.getMirrorUrl() + name + "/resources/logo_180.png", logo_md5);
+        }
+        return new Resource(logo, logo_md5);
+    }
+
+    @Override
+    public String getRecommended() {
+        return recommended;
+    }
+
+    @Override
+    public String getLatest() {
+        return latest;
+    }
+
+    @Override
+    public List<String> getBuilds() {
+        return builds;
+    }
+
+    @Override
+    public boolean shouldForceDirectory() {
+        //TODO: This is not really implemented properly
+        return false;
+    }
+
+    @Override
+    public Modpack getModpack(String build, User user) throws BuildInaccessibleException {
+        try {
+            Modpack pack = RestObject.getRestObject(Modpack.class, SolderConstants.getSolderBuildUrl(solder.getUrl(), name, build, user.getProfile().getName()));
+
+            if (pack != null) {
+                return pack;
+            }
+        } catch (RestfulAPIException e) {
+            throw new BuildInaccessibleException(display_name, build, e);
+        }
+
+        throw new BuildInaccessibleException(display_name, build);
+    }
+
+    @Override
+    public String toString() {
+        return "SolderPackInfo{" +
+                "name='" + name + '\'' +
+                ", display_name='" + display_name + '\'' +
+                ", url='" + url + '\'' +
+                ", icon_md5='" + icon_md5 + '\'' +
+                ", logo_md5='" + logo_md5 + '\'' +
+                ", background_md5='" + background_md5 + '\'' +
+                ", recommended='" + recommended + '\'' +
+                ", latest='" + latest + '\'' +
+                ", builds=" + builds +
+                ", solder=" + solder +
+                '}';
+    }
+
+    public static SolderPackInfo getSolderPackInfo(String url) throws RestfulAPIException {
+        SolderPackInfo info = getRestObject(SolderPackInfo.class, url);
+        if (info == null) {
+            return null;
+        }
+        String solderUrl = url.substring(0, url.length() - info.getName().length() - 1);
+        Solder solder = RestObject.getRestObject(Solder.class, solderUrl);
+        if (solder != null) {
+            solder.setUrl(solderUrl.replace("modpack/", ""));
+            info.setSolder(solder);
+        }
+        return info;
+    }
+
+    public static SolderPackInfo getSolderPackInfo(String solderUrl, String name, User user) throws RestfulAPIException {
+        SolderPackInfo info = getRestObject(SolderPackInfo.class, SolderConstants.getSolderPackInfoUrl(solderUrl, name, user.getProfile().getName()));
+        Solder solder = RestObject.getRestObject(Solder.class, solderUrl + "modpack/");
+        solder.setUrl(solderUrl);
+        info.setSolder(solder);
+        return info;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/restful/solder/SolderPackInfo.java
 }

--- a/src/main/java/net/technicpack/utilslib/DateTypeAdapter.java
+++ b/src/main/java/net/technicpack/utilslib/DateTypeAdapter.java
@@ -19,14 +19,7 @@
 
 package net.technicpack.utilslib;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
-import com.google.gson.JsonSyntaxException;
+import com.google.gson.*;
 
 import java.lang.reflect.Type;
 import java.text.DateFormat;
@@ -36,58 +29,58 @@ import java.util.Date;
 import java.util.Locale;
 
 public class DateTypeAdapter
-		implements JsonDeserializer<Date>, JsonSerializer<Date> {
-	private final DateFormat enUsFormat;
-	private final DateFormat iso8601Format;
+        implements JsonDeserializer<Date>, JsonSerializer<Date> {
+    private final DateFormat enUsFormat;
+    private final DateFormat iso8601Format;
 
-	public DateTypeAdapter() {
-		this.enUsFormat = DateFormat.getDateTimeInstance(2, 2, Locale.US);
-		this.iso8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
-	}
+    public DateTypeAdapter() {
+        this.enUsFormat = DateFormat.getDateTimeInstance(2, 2, Locale.US);
+        this.iso8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+    }
 
-	public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-		if (!(json instanceof JsonPrimitive)) {
-			throw new JsonParseException("The date should be a string value");
-		}
+    public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        if (!(json instanceof JsonPrimitive)) {
+            throw new JsonParseException("The date should be a string value");
+        }
 
-		Date date = deserializeToDate(json);
+        Date date = deserializeToDate(json);
 
-		if (typeOfT == Date.class) {
-			return date;
-		}
-		throw new IllegalArgumentException(getClass() + " cannot deserialize to " + typeOfT);
-	}
+        if (typeOfT == Date.class) {
+            return date;
+        }
+        throw new IllegalArgumentException(getClass() + " cannot deserialize to " + typeOfT);
+    }
 
-	private Date deserializeToDate(JsonElement json) {
-		synchronized (this.enUsFormat) {
-			try {
-				return this.enUsFormat.parse(json.getAsString());
-			} catch (ParseException localParseException) {
-				try {
-					return this.iso8601Format.parse(json.getAsString());
-				} catch (ParseException localParseException1) {
-					try {
-						String cleaned = json.getAsString().replace("Z", "+00:00");
-						cleaned = cleaned.substring(0, 22) + cleaned.substring(23);
-						return this.iso8601Format.parse(cleaned);
-					} catch (Exception e) {
-						throw new JsonSyntaxException("Invalid date: " + json.getAsString(), e);
-					}
-				}
-			}
-		}
-	}
+    private Date deserializeToDate(JsonElement json) {
+        synchronized (this.enUsFormat) {
+            try {
+                return this.enUsFormat.parse(json.getAsString());
+            } catch (ParseException localParseException) {
+                try {
+                    return this.iso8601Format.parse(json.getAsString());
+                } catch (ParseException localParseException1) {
+                    try {
+                        String cleaned = json.getAsString().replace("Z", "+00:00");
+                        cleaned = cleaned.substring(0, 22) + cleaned.substring(23);
+                        return this.iso8601Format.parse(cleaned);
+                    } catch (Exception e) {
+                        throw new JsonSyntaxException("Invalid date: " + json.getAsString(), e);
+                    }
+                }
+            }
+        }
+    }
 
-	public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
-		synchronized (this.enUsFormat) {
-			return new JsonPrimitive(serializeToString(src));
-		}
-	}
+    public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
+        synchronized (this.enUsFormat) {
+            return new JsonPrimitive(serializeToString(src));
+        }
+    }
 
-	private String serializeToString(Date date) {
-		synchronized (this.enUsFormat) {
-			String result = this.iso8601Format.format(date);
-			return result.substring(0, 22) + ":" + result.substring(22);
-		}
-	}
+    private String serializeToString(Date date) {
+        synchronized (this.enUsFormat) {
+            String result = this.iso8601Format.format(date);
+            return result.substring(0, 22) + ":" + result.substring(22);
+        }
+    }
 }

--- a/src/main/java/net/technicpack/utilslib/ImageUtils.java
+++ b/src/main/java/net/technicpack/utilslib/ImageUtils.java
@@ -18,39 +18,38 @@
 
 package net.technicpack.utilslib;
 
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 
 public class ImageUtils {
 
-	public static BufferedImage scaleWithAspectWidth(BufferedImage img, int width) {
-		int imgWidth = img.getWidth();
-		int imgHeight = img.getHeight();
-		int height = imgHeight * width / imgWidth;
-		return scaleImage(img, width, height);
-	}
+    public static BufferedImage scaleWithAspectWidth(BufferedImage img, int width) {
+        int imgWidth = img.getWidth();
+        int imgHeight = img.getHeight();
+        int height = imgHeight * width / imgWidth;
+        return scaleImage(img, width, height);
+    }
 
-	public static BufferedImage scaleImage(BufferedImage img, int width, int height) {
-		BufferedImage newImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-		Graphics2D g = newImage.createGraphics();
-		try {
-			g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-			g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-			g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-			g.drawImage(img, 0, 0, width, height, null);
-		} finally {
-			g.dispose();
-		}
-		return newImage;
-	}
+    public static BufferedImage scaleImage(BufferedImage img, int width, int height) {
+        BufferedImage newImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = newImage.createGraphics();
+        try {
+            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+            g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g.drawImage(img, 0, 0, width, height, null);
+        } finally {
+            g.dispose();
+        }
+        return newImage;
+    }
 
-	public static BufferedImage scaleWithAspectHeight(BufferedImage img, int height) {
-		int imgWidth = img.getWidth();
-		int imgHeight = img.getHeight();
-		int width = imgWidth * height / imgHeight;
-		return scaleImage(img, width, height);
-	}
+    public static BufferedImage scaleWithAspectHeight(BufferedImage img, int height) {
+        int imgWidth = img.getWidth();
+        int imgHeight = img.getHeight();
+        int width = imgWidth * height / imgHeight;
+        return scaleImage(img, width, height);
+    }
 
 
 }

--- a/src/main/java/net/technicpack/utilslib/LowerCaseEnumTypeAdapterFactory.java
+++ b/src/main/java/net/technicpack/utilslib/LowerCaseEnumTypeAdapterFactory.java
@@ -35,36 +35,36 @@ import java.util.Map;
 public class LowerCaseEnumTypeAdapterFactory implements TypeAdapterFactory {
 
     @SuppressWarnings("unchecked")
-	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
-		Class rawType = type.getRawType();
-		if (!rawType.isEnum()) {
-			return null;
-		}
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        Class rawType = type.getRawType();
+        if (!rawType.isEnum()) {
+            return null;
+        }
 
-		final Map<String, T> lowercaseToConstant = new HashMap<String, T>();
-		for (Object constant : rawType.getEnumConstants()) {
-			lowercaseToConstant.put(toLowercase(constant), (T) constant);
-		}
+        final Map<String, T> lowercaseToConstant = new HashMap<String, T>();
+        for (Object constant : rawType.getEnumConstants()) {
+            lowercaseToConstant.put(toLowercase(constant), (T) constant);
+        }
 
-		return new TypeAdapter<T>() {
-			public void write(JsonWriter out, T value) throws IOException {
-				if (value == null)
-					out.nullValue();
-				else
-					out.value(LowerCaseEnumTypeAdapterFactory.this.toLowercase(value));
-			}
+        return new TypeAdapter<T>() {
+            public void write(JsonWriter out, T value) throws IOException {
+                if (value == null)
+                    out.nullValue();
+                else
+                    out.value(LowerCaseEnumTypeAdapterFactory.this.toLowercase(value));
+            }
 
-			public T read(JsonReader reader) throws IOException {
-				if (reader.peek() == JsonToken.NULL) {
-					reader.nextNull();
-					return null;
-				}
-				return lowercaseToConstant.get(reader.nextString());
-			}
-		};
-	}
+            public T read(JsonReader reader) throws IOException {
+                if (reader.peek() == JsonToken.NULL) {
+                    reader.nextNull();
+                    return null;
+                }
+                return lowercaseToConstant.get(reader.nextString());
+            }
+        };
+    }
 
-	private String toLowercase(Object o) {
-		return o.toString().toLowerCase(Locale.US);
-	}
+    private String toLowercase(Object o) {
+        return o.toString().toLowerCase(Locale.US);
+    }
 }

--- a/src/main/java/net/technicpack/utilslib/MD5Utils.java
+++ b/src/main/java/net/technicpack/utilslib/MD5Utils.java
@@ -19,33 +19,34 @@
 
 package net.technicpack.utilslib;
 
+import org.apache.commons.codec.digest.DigestUtils;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import org.apache.commons.codec.digest.DigestUtils;
 
 public class MD5Utils {
 
-	public static String getMD5(File file) {
-		try {
-			FileInputStream fis = new FileInputStream(file);
-			String md5 = DigestUtils.md5Hex(fis);
-			fis.close();
-			return md5;
-		} catch (FileNotFoundException e) {
-			e.printStackTrace();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		return null;
-	}
+    public static String getMD5(File file) {
+        try {
+            FileInputStream fis = new FileInputStream(file);
+            String md5 = DigestUtils.md5Hex(fis);
+            fis.close();
+            return md5;
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
 
-	public static boolean checkMD5(File file, String md5) {
-		return checkMD5(md5, getMD5(file));
-	}
+    public static boolean checkMD5(File file, String md5) {
+        return checkMD5(md5, getMD5(file));
+    }
 
-	public static boolean checkMD5(String md5, String otherMd5) {
-		return md5.equalsIgnoreCase(otherMd5);
-	}
+    public static boolean checkMD5(String md5, String otherMd5) {
+        return md5.equalsIgnoreCase(otherMd5);
+    }
 }

--- a/src/main/java/net/technicpack/utilslib/OperatingSystem.java
+++ b/src/main/java/net/technicpack/utilslib/OperatingSystem.java
@@ -23,61 +23,71 @@ import java.io.File;
 import java.util.Locale;
 
 public enum OperatingSystem {
-	LINUX("linux", new String[]{"linux", "unix"}),
-	WINDOWS("windows", new String[]{"win"}),
-	OSX("osx", new String[]{"mac"}),
-	UNKNOWN("unknown", new String[0]);
+    LINUX("linux", new String[]{"linux", "unix"}),
+    WINDOWS("windows", new String[]{"win"}),
+    OSX("osx", new String[]{"mac"}),
+    UNKNOWN("unknown", new String[0]);
 
-	private static OperatingSystem operatingSystem;
-	private final String name;
-	private final String[] aliases;
+    private static OperatingSystem operatingSystem;
+    private final String name;
+    private final String[] aliases;
 
-	private OperatingSystem(String name, String[] aliases) {
-		this.name = name;
-		this.aliases = aliases;
-	}
+    private OperatingSystem(String name, String[] aliases) {
+        this.name = name;
+        this.aliases = aliases;
+    }
 
-	public static String getJavaDir() {
-		String separator = System.getProperty("file.separator");
-		String path = System.getProperty("java.home") + separator + "bin" + separator;
+    public static String getJavaDir() {
+        String separator = System.getProperty("file.separator");
+        String path = System.getProperty("java.home") + separator + "bin" + separator;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/utilslib/OperatingSystem.java
 		if (getOperatingSystem() == WINDOWS) {
 			return "javaw.exe";
 		}
 
 		return "java";
 	}
+=======
+        if ((getOperatingSystem() == WINDOWS) &&
+                (new File(path + "javaw.exe").isFile())) {
+            return path + "javaw.exe";
+        }
 
-	public static OperatingSystem getOperatingSystem() {
-		if (OperatingSystem.operatingSystem != null) {
-			return OperatingSystem.operatingSystem;
-		}
+        return path + "java";
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/util/OperatingSystem.java
 
-		//Always specify english when tolowercase/touppercasing values for comparison against well-known values
-		//Prevents an issue with turkish users
-		String osName = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+    public static OperatingSystem getOperatingSystem() {
+        if (OperatingSystem.operatingSystem != null) {
+            return OperatingSystem.operatingSystem;
+        }
 
-		for (OperatingSystem operatingSystem : values()) {
-			for (String alias : operatingSystem.getAliases()) {
-				if (osName.contains(alias)) {
-					OperatingSystem.operatingSystem = operatingSystem;
-					return operatingSystem;
-				}
-			}
-		}
+        //Always specify english when tolowercase/touppercasing values for comparison against well-known values
+        //Prevents an issue with turkish users
+        String osName = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
 
-		return UNKNOWN;
-	}
+        for (OperatingSystem operatingSystem : values()) {
+            for (String alias : operatingSystem.getAliases()) {
+                if (osName.contains(alias)) {
+                    OperatingSystem.operatingSystem = operatingSystem;
+                    return operatingSystem;
+                }
+            }
+        }
 
-	public String[] getAliases() {
-		return aliases;
-	}
+        return UNKNOWN;
+    }
 
-	public String getName() {
-		return name;
-	}
+    public String[] getAliases() {
+        return aliases;
+    }
 
-	public boolean isSupported() {
-		return this != UNKNOWN;
-	}
+    public String getName() {
+        return name;
+    }
+
+    public boolean isSupported() {
+        return this != UNKNOWN;
+    }
 }

--- a/src/main/java/net/technicpack/utilslib/Utils.java
+++ b/src/main/java/net/technicpack/utilslib/Utils.java
@@ -25,17 +25,22 @@ import net.technicpack.utilslib.DateTypeAdapter;
 import net.technicpack.utilslib.LowerCaseEnumTypeAdapterFactory;
 import org.apache.commons.io.IOUtils;
 
+<<<<<<< HEAD:src/main/java/net/technicpack/utilslib/Utils.java
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+=======
+import java.io.*;
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/util/Utils.java
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Date;
 import java.util.logging.Logger;
 
 public class Utils {
+<<<<<<< HEAD:src/main/java/net/technicpack/utilslib/Utils.java
 	private static final Gson gson;
 	private static final Logger logger = Logger.getLogger("net.technicpack.launcher.Main");
 
@@ -137,4 +142,137 @@ public class Utils {
 			return false;
 		}
 	}
+=======
+    private static final Gson gson;
+    private static final Gson mojangGson;
+    private static final Logger logger = Logger.getLogger("net.technicpack.launcher.Main");
+
+    static {
+        GsonBuilder builder = new GsonBuilder();
+        builder.setPrettyPrinting();
+        builder.registerTypeAdapterFactory(new LowerCaseEnumTypeAdapterFactory());
+        builder.registerTypeAdapter(Date.class, new DateTypeAdapter());
+        builder.enableComplexMapKeySerialization();
+        mojangGson = builder.create();
+        builder = new GsonBuilder();
+        builder.setPrettyPrinting();
+        gson = builder.create();
+    }
+
+    public static Gson getGson() {
+        return gson;
+    }
+
+    public static Gson getMojangGson() {
+        return mojangGson;
+    }
+
+    public static File getLauncherDirectory() {
+        return Directories.instance.getLauncherDirectory();
+    }
+
+    public static File getSettingsDirectory() {
+        return Directories.instance.getSettingsDirectory();
+    }
+
+    public static File getCacheDirectory() {
+        return Directories.instance.getCacheDirectory();
+    }
+
+    public static File getAssetsDirectory() {
+        return Directories.instance.getAssetsDirectory();
+    }
+
+    public static File getModpacksDirectory() {
+        return Directories.instance.getModpacksDirectory();
+    }
+
+    public static Logger getLogger() {
+        return logger;
+    }
+
+    /**
+     * Establishes an HttpURLConnection from a URL, with the correct configuration to receive content from the given URL.
+     *
+     * @param url The URL to set up and receive content from
+     * @return A valid HttpURLConnection
+     * @throws IOException The openConnection() method throws an IOException and the calling method is responsible for handling it.
+     */
+    public static HttpURLConnection openHttpConnection(URL url) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setDoInput(true);
+        conn.setDoOutput(false);
+        System.setProperty("http.agent", "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.162 Safari/535.19");
+        conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.162 Safari/535.19");
+        HttpURLConnection.setFollowRedirects(true);
+        conn.setUseCaches(false);
+        conn.setInstanceFollowRedirects(true);
+        return conn;
+    }
+
+    /**
+     * Opens an HTTP connection to a web URL and tests that the response is a valid 200-level code
+     * and we can successfully open a stream to the content.
+     *
+     * @param urlLoc The HTTP URL indicating the location of the content.
+     * @return True if the content can be accessed successfully, false otherwise.
+     */
+    public static boolean pingHttpURL(String urlLoc, MirrorStore mirrorStore) {
+        InputStream stream = null;
+        try {
+            final URL url = mirrorStore.getFullUrl(urlLoc);
+            final HttpURLConnection conn = openHttpConnection(url);
+            conn.setConnectTimeout(10000);
+
+            int responseCode = conn.getResponseCode();
+            int responseFamily = responseCode / 100;
+
+            if (responseFamily == 2) {
+                stream = conn.getInputStream();
+                return true;
+            } else {
+                return false;
+            }
+        } catch (IOException e) {
+            return false;
+        } finally {
+            IOUtils.closeQuietly(stream);
+        }
+    }
+
+    public static boolean sendTracking(String category, String action, String label) {
+        String url = "http://www.google-analytics.com/collect";
+        try {
+            URL urlObj = new URL(url);
+            HttpURLConnection con = (HttpURLConnection) urlObj.openConnection();
+            con.setRequestMethod("POST");
+
+            String urlParameters = "v=1&tid=UA-30896795-3&cid=" + Settings.getClientId() + "&t=event&ec=" + category + "&ea=" + action + "&el=" + label;
+
+            con.setDoOutput(true);
+            DataOutputStream wr = new DataOutputStream(con.getOutputStream());
+            wr.writeBytes(urlParameters);
+            wr.flush();
+            wr.close();
+
+            int responseCode = con.getResponseCode();
+            System.out.println("Analytics Response [" + category + "]: " + responseCode);
+
+            BufferedReader in = new BufferedReader(
+                    new InputStreamReader(con.getInputStream()));
+            String inputLine;
+            StringBuffer response = new StringBuffer();
+
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+
+
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/util/Utils.java
 }

--- a/src/main/java/net/technicpack/utilslib/XMLUtils.java
+++ b/src/main/java/net/technicpack/utilslib/XMLUtils.java
@@ -28,27 +28,27 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 
 public class XMLUtils {
-	static DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
-	static DocumentBuilder docBuilder;
+    static DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+    static DocumentBuilder docBuilder;
 
-	public static Document getXMLFromURL(String url) {
-		Document xmlDoc = null;
+    public static Document getXMLFromURL(String url) {
+        Document xmlDoc = null;
 
-		try {
-			docBuilder = builderFactory.newDocumentBuilder();
-			xmlDoc = docBuilder.parse(url);
-		} catch (ParserConfigurationException error) {
-			System.err.println("Error reading parser configuration.");
-			return xmlDoc;
-		} catch (SAXException error) {
-			System.err.println("Error parsing document.");
-			return xmlDoc;
-		} catch (IOException error) {
-			System.err.println("Error accessing URL.");
-			return xmlDoc;
-		}
+        try {
+            docBuilder = builderFactory.newDocumentBuilder();
+            xmlDoc = docBuilder.parse(url);
+        } catch (ParserConfigurationException error) {
+            System.err.println("Error reading parser configuration.");
+            return xmlDoc;
+        } catch (SAXException error) {
+            System.err.println("Error parsing document.");
+            return xmlDoc;
+        } catch (IOException error) {
+            System.err.println("Error accessing URL.");
+            return xmlDoc;
+        }
 
-		xmlDoc.getDocumentElement().normalize();
-		return xmlDoc;
-	}
+        xmlDoc.getDocumentElement().normalize();
+        return xmlDoc;
+    }
 }

--- a/src/main/java/net/technicpack/utilslib/ZipUtils.java
+++ b/src/main/java/net/technicpack/utilslib/ZipUtils.java
@@ -22,12 +22,7 @@ package net.technicpack.utilslib;
 import net.technicpack.launchercore.util.DownloadListener;
 import org.apache.commons.io.IOUtils;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -39,6 +34,7 @@ import java.util.zip.ZipFile;
 
 public class ZipUtils {
 
+<<<<<<< HEAD:src/main/java/net/technicpack/utilslib/ZipUtils.java
 	public static boolean checkLaunchDirectory(File dir) {
 		if (!dir.isDirectory()) {
 			return false;
@@ -158,4 +154,185 @@ public class ZipUtils {
 			zipFile.close();
 		}
 	}
+=======
+    public static boolean checkLaunchDirectory(File dir) {
+        if (!dir.isDirectory()) {
+            return false;
+        }
+
+        if (dir.list().length == 0) {
+            return true;
+        }
+
+        for (File file : dir.listFiles()) {
+            if (file.getName().equals("settings.json")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if a directory is empty
+     *
+     * @param dir to check
+     * @return true if the directory is empty
+     */
+    public static boolean checkEmpty(File dir) {
+        return dir.isDirectory() && dir.list().length == 0;
+
+    }
+
+    public static boolean extractFile(File zip, File output, String fileName) throws IOException {
+        if (!zip.exists() || fileName == null) {
+            return false;
+        }
+
+        ZipFile zipFile = new ZipFile(zip);
+        try {
+            ZipEntry entry = zipFile.getEntry(fileName);
+            if (entry == null) {
+                Utils.getLogger().log(Level.WARNING, "File " + fileName + " not found in " + zip.getAbsolutePath());
+                return false;
+            }
+            File outputFile = new File(output, entry.getName());
+
+            if (outputFile.getParentFile() != null) {
+                outputFile.getParentFile().mkdirs();
+            }
+
+            unzipEntry(zipFile, zipFile.getEntry(fileName), outputFile);
+            return true;
+        } catch (IOException e) {
+            Utils.getLogger().log(Level.WARNING, "Error extracting file " + fileName + " from " + zip.getAbsolutePath());
+            return false;
+        } finally {
+            zipFile.close();
+        }
+    }
+
+    private static void unzipEntry(ZipFile zipFile, ZipEntry entry, File outputFile) throws IOException {
+        byte[] buffer = new byte[2048];
+        BufferedInputStream inputStream = new BufferedInputStream(zipFile.getInputStream(entry));
+        BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(outputFile));
+        try {
+            int length;
+            while ((length = inputStream.read(buffer, 0, buffer.length)) != -1) {
+                outputStream.write(buffer, 0, length);
+            }
+        } finally {
+            IOUtils.closeQuietly(outputStream);
+            IOUtils.closeQuietly(inputStream);
+        }
+    }
+
+    public static void unzipFile(File zip, File output, DownloadListener listener) throws IOException {
+        unzipFile(zip, output, null, listener);
+    }
+
+    /**
+     * Unzips a file into the specified directory.
+     *
+     * @param zip          file to unzip
+     * @param output       directory to unzip into
+     * @param extractRules extractRules for this zip file. May be null indicating no rules.
+     * @param listener     to update progress on - may be null for no progress indicator
+     */
+    public static void unzipFile(File zip, File output, ExtractRules extractRules, DownloadListener listener) throws IOException {
+        if (!zip.exists()) {
+            Utils.getLogger().log(Level.SEVERE, "File to unzip does not exist: " + zip.getAbsolutePath());
+            return;
+        }
+        if (!output.exists()) {
+            output.mkdirs();
+        }
+
+        ZipFile zipFile = new ZipFile(zip);
+        int size = zipFile.size() + 1;
+        int progress = 1;
+        try {
+            Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = null;
+
+                try {
+                    entry = entries.nextElement();
+                } catch (IllegalArgumentException ex) {
+                    //We must catch & rethrow as a zip exception because some crappy code in the zip lib will
+                    //throw illegal argument exceptions for malformed zips.
+                    throw new ZipException("IllegalArgumentException while parsing next element.");
+                }
+
+                if ((extractRules == null || extractRules.shouldExtract(entry.getName())) && !entry.getName().contains("../")) {
+                    File outputFile = new File(output, entry.getName());
+
+                    if (outputFile.getParentFile() != null) {
+                        outputFile.getParentFile().mkdirs();
+                    }
+
+                    if (!entry.isDirectory()) {
+                        unzipEntry(zipFile, entry, outputFile);
+                    }
+                }
+
+                if (listener != null) {
+                    float totalProgress = (float) progress / (float) size;
+                    listener.stateChanged("Extracting " + entry.getName() + "...", totalProgress * 100.0f);
+                }
+                progress++;
+            }
+        } finally {
+            zipFile.close();
+        }
+    }
+
+    public static void copyMinecraftJar(File minecraft, File output) throws IOException {
+        String[] security = {"MOJANG_C.DSA",
+                "MOJANG_C.SF",
+                "CODESIGN.RSA",
+                "CODESIGN.SF"};
+        JarFile jarFile = new JarFile(minecraft);
+        try {
+            String fileName = jarFile.getName();
+            String fileNameLastPart = fileName.substring(fileName.lastIndexOf(File.separator));
+
+            JarOutputStream jos = new JarOutputStream(new FileOutputStream(output));
+            Enumeration<JarEntry> entries = jarFile.entries();
+
+            while (entries.hasMoreElements()) {
+                JarEntry entry = entries.nextElement();
+                if (containsAny(entry.getName(), security)) {
+                    continue;
+                }
+                InputStream is = jarFile.getInputStream(entry);
+
+                //jos.putNextEntry(entry);
+                //create a new entry to avoid ZipException: invalid entry compressed size
+                jos.putNextEntry(new JarEntry(entry.getName()));
+                byte[] buffer = new byte[4096];
+                int bytesRead = 0;
+                while ((bytesRead = is.read(buffer)) != -1) {
+                    jos.write(buffer, 0, bytesRead);
+                }
+                is.close();
+                jos.flush();
+                jos.closeEntry();
+            }
+            jos.close();
+        } finally {
+            jarFile.close();
+        }
+
+    }
+
+    private static boolean containsAny(String inputString, String[] contains) {
+        for (String string : contains) {
+            if (inputString.contains(string)) {
+                return true;
+            }
+        }
+        return false;
+    }
+>>>>>>> Re-tab & optimize imports for all files in core.:src/main/java/net/technicpack/launchercore/util/ZipUtils.java
 }


### PR DESCRIPTION
This should fix providing a URL shortener (ex: goo.gl) as long as they properly return a 3xx HTTP status code. All of these status codes require that the URL of the redirect target be given in the "Location" header of the HTTP response.