### PR TITLE
Linux and Mac don't know what an .exe is ;-)

### DIFF
--- a/src/main/java/net/technicpack/utilslib/OperatingSystem.java
+++ b/src/main/java/net/technicpack/utilslib/OperatingSystem.java
@@ -45,7 +45,7 @@ public enum OperatingSystem {
 			return "javaw.exe";
 		}
 
-		return "java.exe";
+		return "java";
 	}
 
 	public static OperatingSystem getOperatingSystem() {


### PR DESCRIPTION
Without this at least vanilla Minecraft does not start on Linux (and won't start on Mac either)
