### PR TITLE
#29: Use add path return the correct java dir/executable.

### DIFF
--- a/src/main/java/net/technicpack/utilslib/OperatingSystem.java
+++ b/src/main/java/net/technicpack/utilslib/OperatingSystem.java
@@ -47,6 +47,21 @@ public enum OperatingSystem {
         return path + "java";
     }
 
+    public static String getJavaDir( String javaHome ) {
+        String separator = System.getProperty("file.separator");
+        String path = javaHome;
+    	if ( path == null || "".equals(path.trim()) ) { 
+            path = System.getProperty("java.home");
+    	}
+    	path = path + separator + "bin" + separator;
+
+        if (getOperatingSystem() == WINDOWS) {
+            return path + "javaw.exe";
+        }
+
+        return path + "java";
+    }
+
     public static OperatingSystem getOperatingSystem() {
         if (OperatingSystem.operatingSystem != null) {
             return OperatingSystem.operatingSystem;

--- a/src/main/java/net/technicpack/utilslib/OperatingSystem.java
+++ b/src/main/java/net/technicpack/utilslib/OperatingSystem.java
@@ -41,10 +41,10 @@ public enum OperatingSystem {
         String path = System.getProperty("java.home") + separator + "bin" + separator;
 
         if (getOperatingSystem() == WINDOWS) {
-            return "javaw.exe";
+            return path + "javaw.exe";
         }
 
-        return "java";
+        return path + "java";
     }
 
     public static OperatingSystem getOperatingSystem() {


### PR DESCRIPTION
The constructed path is prepended to the java command.